### PR TITLE
release: workflow_dispatch input on auto-release.yml

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,10 +1,17 @@
-name: Auto-release on PR merge
+name: Auto-release
 
-# Triggers when a PR is merged to main carrying a release:patch /
-# release:minor / release:major label. The workflow computes the next
-# semver from the latest existing v*.*.* tag, runs scripts/release.sh
-# to promote CHANGELOG.md and create the tag, and creates the matching
-# GitHub Release in the same job.
+# Two trigger paths:
+#
+#   1. PR merged to main carrying a release:patch / release:minor /
+#      release:major label → bump computed from the label.
+#   2. Manual workflow_dispatch from the Actions tab → either a
+#      `bump` choice (patch/minor/major) or an explicit `version`
+#      (X.Y.Z), with version overriding bump if both are supplied.
+#
+# In either case the workflow:
+#   - Computes the next version (or uses the explicit one)
+#   - Runs scripts/release.sh to promote CHANGELOG + tag
+#   - Creates the matching GitHub Release inline
 #
 # Why "in the same job": tags pushed by GITHUB_TOKEN do NOT trigger
 # downstream workflows (the well-known token recursion guard). So the
@@ -13,82 +20,116 @@ name: Auto-release on PR merge
 # manual `make release-push` path where the maintainer pushes the tag
 # from their own credentials.
 #
-# PRs without a release label are silently skipped — the [Unreleased]
-# entries simply accumulate until a release-labelled PR triggers the
-# next bump.
+# PR-trigger path: PRs without a release label are silently skipped —
+# the [Unreleased] entries simply accumulate until a release-labelled
+# PR triggers the next bump.
 
 on:
   pull_request:
     types: [closed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Explicit X.Y.Z (e.g. 0.2.0). Overrides 'bump' if both supplied. Leave empty to use 'bump'."
+        required: false
+        type: string
+        default: ""
+      bump:
+        description: "Bump type when 'version' is empty."
+        required: false
+        type: choice
+        default: "patch"
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write   # push commit + tag + create Release
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    # Run when a PR was actually merged (closed-but-not-merged → skip)
+    # or whenever the workflow is triggered manually.
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+      || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - name: Determine bump type from PR labels
-        id: bump
-        env:
-          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-        run: |
-          set -euo pipefail
-          # JSON array of label names → bump type. major beats minor
-          # beats patch when multiple labels are present (rare, but
-          # handle it deterministically rather than failing).
-          bump=$(printf '%s' "$LABELS" | jq -r '
-            if any(. == "release:major") then "major"
-            elif any(. == "release:minor") then "minor"
-            elif any(. == "release:patch") then "patch"
-            else empty
-            end
-          ')
-          if [ -z "$bump" ]; then
-            echo "no release:* label on PR; skipping auto-release"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "bump=$bump" >> "$GITHUB_OUTPUT"
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout main
-        if: steps.bump.outputs.skip == 'false'
         uses: actions/checkout@v6
         with:
           ref: main
-          fetch-depth: 0   # need full history + tags
+          fetch-depth: 0   # full history + tags
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Compute next version
-        if: steps.bump.outputs.skip == 'false'
+      - name: Determine version
         id: version
+        env:
+          EVENT: ${{ github.event_name }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_BUMP: ${{ inputs.bump }}
         run: |
           set -euo pipefail
+
+          # 1. Manual dispatch with explicit version → use it directly,
+          #    skip bump computation.
+          if [ "$EVENT" = "workflow_dispatch" ] && [ -n "$INPUT_VERSION" ]; then
+            echo "Using explicit version from input: $INPUT_VERSION"
+            echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 2. Pick a bump type from either the dispatch input or the
+          #    PR's release:* label. PR with no release label → skip
+          #    the whole job.
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            bump="$INPUT_BUMP"
+          else
+            bump=$(printf '%s' "$LABELS" | jq -r '
+              if any(. == "release:major") then "major"
+              elif any(. == "release:minor") then "minor"
+              elif any(. == "release:patch") then "patch"
+              else empty
+              end
+            ')
+            if [ -z "$bump" ]; then
+              echo "::notice::No release:* label on PR — skipping auto-release."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          # 3. Compute next version from latest existing tag + bump.
           latest=$(git tag -l 'v*' --sort=-v:refname | head -n 1)
           if [ -z "$latest" ]; then
-            echo "error: no existing v*.*.* tags to bump from" >&2
+            echo "::error::no existing v*.*.* tags to bump from. Use the 'version' input on workflow_dispatch to seed an initial release."
             exit 1
           fi
           latest=${latest#v}
           IFS='.' read -r major minor patch <<< "$latest"
-          case "${{ steps.bump.outputs.bump }}" in
+          case "$bump" in
             major) major=$((major+1)); minor=0; patch=0 ;;
             minor) minor=$((minor+1)); patch=0 ;;
             patch) patch=$((patch+1)) ;;
+            *) echo "::error::unknown bump type: $bump"; exit 1 ;;
           esac
-          echo "version=$major.$minor.$patch" >> "$GITHUB_OUTPUT"
+          version="$major.$minor.$patch"
+          echo "Computed version: v$version (latest=$latest, bump=$bump)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Configure git identity
-        if: steps.bump.outputs.skip == 'false'
+        if: steps.version.outputs.skip == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Run release script
-        if: steps.bump.outputs.skip == 'false'
+        if: steps.version.outputs.skip == 'false'
         # Invoked via `bash` rather than relying on the executable
         # bit, since Windows-committed files can end up with the bit
         # unset — the check-in machine may not preserve mode in git
@@ -96,7 +137,7 @@ jobs:
         run: bash scripts/release.sh ${{ steps.version.outputs.version }} --push
 
       - name: Extract CHANGELOG section for the new tag
-        if: steps.bump.outputs.skip == 'false'
+        if: steps.version.outputs.skip == 'false'
         id: notes
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -109,7 +150,7 @@ jobs:
             in_section { print }
           ' CHANGELOG.md | sed -e '/./,$!d' -e ':a;/^\n*$/{$d;N;ba;}')"
           if [ -z "$body" ]; then
-            echo "error: no CHANGELOG entry for v${VERSION}" >&2
+            echo "::error::no CHANGELOG entry for v${VERSION}"
             exit 1
           fi
           {
@@ -119,7 +160,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        if: steps.bump.outputs.skip == 'false'
+        if: steps.version.outputs.skip == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,9 +131,17 @@ Add a `release:patch`, `release:minor`, or `release:major` label to a PR before 
 
 **PRs without a release label are silently skipped** — `[Unreleased]` entries accumulate until the next release-labelled PR triggers a bump.
 
-### Path 2 — Manual, from a maintainer's checkout
+### Path 2 — Manual via GitHub UI
 
-For releases that aren't tied to a single PR (e.g. cutting a release that bundles several already-merged PRs):
+For releases that aren't tied to a single PR (e.g. cutting a release that bundles several already-merged PRs), or to retry a failed auto-release:
+
+1. Go to **Actions** → **"Auto-release"** → **"Run workflow"**
+2. Either pick a `bump` type (default: `patch`) or enter an explicit `version` (`X.Y.Z`). If both are supplied, `version` wins.
+3. Confirm
+
+The same flow as the PR-merge path runs: CHANGELOG promoted, commit + tag created, GitHub Release published.
+
+### Path 3 — Manual from a maintainer's checkout
 
 ```bash
 git checkout main && git pull
@@ -150,7 +158,9 @@ Run `make release VERSION=X.Y.Z` (without `-push`) first if you want to inspect 
 
 ### Why two workflows?
 
-`auto-release.yml` does its own GitHub Release creation inline because tags pushed by `GITHUB_TOKEN` don't trigger downstream workflows (the well-known recursion guard). `release.yml` still handles the manual-tag case where the maintainer pushes the tag from their own credentials, which DO trigger workflows.
+`auto-release.yml` does its own GitHub Release creation inline because tags pushed by `GITHUB_TOKEN` don't trigger downstream workflows (the well-known recursion guard). `release.yml` still handles Path 3, where the maintainer pushes the tag from their own credentials, which DO trigger workflows.
+
+Both PR-merge and `workflow_dispatch` paths go through `auto-release.yml`; pick whichever fits the situation.
 
 If you ever need to redo a release (typo in the changelog, etc.):
 


### PR DESCRIPTION
Add a manual trigger to auto-release.yml so the release flow can be fired from Actions → Run workflow without a label-carrying PR merge. Useful for:

  - Retrying a failed auto-release (e.g. after the v0.2.0 chmod + actions allowlist issues)
  - Cutting a release that bundles already-merged unlabeled PRs
  - Seeding the very first release on a repo with no existing tags (via the explicit `version` input)

Inputs:
  - `version` (string, optional): X.Y.Z exact. Overrides `bump`.
  - `bump` (choice, default "patch"): used when `version` is empty.

The determine-version step now handles three paths: explicit version (dispatch only), bump-from-PR-label (pull_request path), or bump-from-dispatch-input. All converge on the same output. Job gate also updated to run on workflow_dispatch events.

CONTRIBUTING.md renumbered: Path 1 (PR-merge automation), Path 2 (workflow_dispatch from Actions UI), Path 3 (maintainer's checkout via make release-push).