### PR TITLE
release: inject Release body via env var, not template substitution

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -163,8 +163,19 @@ jobs:
         if: steps.version.outputs.skip == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          # The body is injected via env var rather than ${{ }}
+          # template substitution. Template values are pasted
+          # LITERALLY into the run: script at parse time — any
+          # backticks or $VAR in the changelog (and there are many)
+          # would then be shell-interpreted as command substitution
+          # / variable expansion, mangling the notes and flooding
+          # the log with "command not found" errors. Env-var
+          # expansion in bash doesn't interpret content inside the
+          # variable's value, so "$BODY" stays verbatim.
+          BODY: ${{ steps.notes.outputs.body }}
         run: |
-          gh release create "v${{ steps.version.outputs.version }}" \
-            --title "v${{ steps.version.outputs.version }}" \
-            --notes "${{ steps.notes.outputs.body }}" \
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes "$BODY" \
             --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,12 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Inject the body via env var so backticks + $VAR in the
+          # CHANGELOG aren't shell-interpreted at template-expansion
+          # time — see the same note in auto-release.yml.
+          BODY: ${{ steps.notes.outputs.body }}
         run: |
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
-            --notes "${{ steps.notes.outputs.body }}" \
+            --notes "$BODY" \
             --verify-tag


### PR DESCRIPTION
The auto-release run for v0.2.0 succeeded (tag + release both created) but flooded the log with shell errors like "pkg/constraint: No such file or directory" and "CHANGELOG.md: command not found". Cause: the body was spliced into the `run:` script via ${{ steps.notes.outputs.body }}, which pastes the value LITERALLY at template-parse time. Every backtick in the changelog became command substitution, every $VAR became variable expansion — bash tried (and failed) to execute the entire contents of the section as a series of commands before gh release create fired.

The release eventually got created because the step didn't have `set -e`, but with a mangled notes body.

Fix in both auto-release.yml and release.yml: pass the body as an env var (BODY: ${{ steps.notes.outputs.body }}) and reference it with "$BODY" in the run:. Env-var expansion in bash doesn't interpret content inside the value, so backticks and $VAR stay literal.

The existing v0.2.0 release body on GitHub will need to be edited manually (or re-created) — the shipped tag is fine, just the release notes are wrong.