### PR TITLE
feat: wire Terraform stdlib functions into EvalContext (issue #16, batch 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to tflens are documented here. The format is loosely based o
 
 ## [Unreleased]
 
+### Changed
+
+- **Terraform stdlib functions wired into `Module.EvalContext`** (issue #16, batch 1). New `pkg/analysis/stdlib` subpackage exposes `Functions()` returning the 16-function curated set: 6 type-conversion (`toset`, `tolist`, `tomap`, `tostring`, `tonumber`, `tobool`) + 10 core collection (`length`, `concat`, `merge`, `keys`, `values`, `lookup`, `contains`, `element`, `flatten`, `distinct`). All implementations come from `cty/function/stdlib` so behaviour matches Terraform exactly. Callers (tracked-attribute diff in `pkg/diff/tracked.go`, sensitive-local detection in `pkg/statediff`) now suppress false positives where text differs but the evaluated value matches — e.g. `local.regions = ["a","b"]` vs `local.regions = distinct(["a","b"])` no longer flags as a change. New `analysis.ValueEquivalent` helper bridges cty's strict Tuple↔List↔Set distinction via JSON marshalling so the type difference between a literal tuple and a function-returned list doesn't defeat the equivalence check. Per-function table tests under `pkg/analysis/stdlib/testdata/<func>/main.tf` (19 cases) plus end-to-end statediff suppression tests under `pkg/statediff/testdata/effective_value_collapse/<case>/{main,feature}/main.tf` (4 cases) and tracked-attribute end-to-end tests under `pkg/diff/testdata/tracked_eval_*` (3 cases) — all confirming both the suppression for value-identical changes AND that real value differences still flag.
+
 ## [0.2.2] — 2026-04-25
 
 ### Fixed

--- a/pkg/analysis/equiv.go
+++ b/pkg/analysis/equiv.go
@@ -1,0 +1,44 @@
+package analysis
+
+import (
+	"bytes"
+
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+// ValueEquivalent reports whether old and new are the same value
+// after ignoring the cty Tuple↔List↔Set distinction. cty's
+// RawEquals is type-strict — a literal `["a","b"]` (Tuple) and
+// `distinct(["a","b"])` (List of String) compare not-equal under
+// RawEquals, even though both produce identical for_each / count
+// expansions in Terraform and identical downstream behaviour.
+//
+// JSON marshalling collapses the type distinction: tuple, list, and
+// set all serialise to the same JSON-array shape, and object/map to
+// the same JSON-object shape. Byte-equal JSON means the values
+// would behave identically downstream. Genuine differences (numeric
+// vs string, different elements, different keys) still serialise
+// differently and so still flag.
+//
+// Used by pkg/diff (tracked-attribute effective-value collapse) and
+// pkg/statediff (sensitive-local effective-value collapse) when the
+// new function-evaluation surface produces values whose cty types
+// don't line up exactly across two sides of a comparison.
+//
+// On a marshal error (defensive — shouldn't happen for well-typed
+// values from a successful Eval), falls back to RawEquals.
+func ValueEquivalent(old, neu cty.Value) bool {
+	if old.RawEquals(neu) {
+		return true
+	}
+	oldJSON, err := ctyjson.Marshal(old, old.Type())
+	if err != nil {
+		return false
+	}
+	newJSON, err := ctyjson.Marshal(neu, neu.Type())
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(oldJSON, newJSON)
+}

--- a/pkg/analysis/stdlib/stdlib.go
+++ b/pkg/analysis/stdlib/stdlib.go
@@ -1,0 +1,55 @@
+// Package stdlib registers the Terraform-language built-in functions
+// that pkg/analysis wires into Module.EvalContext for static
+// expression evaluation.
+//
+// The set is intentionally a curated subset (NOT every Terraform
+// built-in) — see the project's CLAUDE.md for the rationale on
+// what's in vs. out. Adding a new batch of functions is a single
+// edit to Functions().
+//
+// All implementations come from cty/function/stdlib, which is the
+// same library Terraform itself uses for these specific functions.
+// Wrapping them here means our evaluation behaviour matches
+// Terraform's exactly for the functions we cover. Functions that
+// would need filesystem access (file, fileset, templatefile),
+// non-deterministic state (timestamp, uuid, bcrypt), or full
+// evaluator catch-and-retry semantics (can, try) are intentionally
+// excluded so the curated set stays evaluation-pure.
+package stdlib
+
+import (
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+// Functions returns the curated Terraform-stdlib function set keyed
+// by the lowercase Terraform-source name (e.g. "length", "toset").
+// Suitable for plugging into hcl.EvalContext{Functions: ...}.
+//
+// A fresh map is constructed per call so callers may mutate the
+// returned value (e.g. to swap an implementation in tests) without
+// affecting other callers.
+func Functions() map[string]function.Function {
+	return map[string]function.Function{
+		// Type conversion — pure type-system bridges.
+		"toset":    stdlib.MakeToFunc(cty.Set(cty.DynamicPseudoType)),
+		"tolist":   stdlib.MakeToFunc(cty.List(cty.DynamicPseudoType)),
+		"tomap":    stdlib.MakeToFunc(cty.Map(cty.DynamicPseudoType)),
+		"tostring": stdlib.MakeToFunc(cty.String),
+		"tonumber": stdlib.MakeToFunc(cty.Number),
+		"tobool":   stdlib.MakeToFunc(cty.Bool),
+
+		// Core collection operations.
+		"length":   stdlib.LengthFunc,
+		"concat":   stdlib.ConcatFunc,
+		"merge":    stdlib.MergeFunc,
+		"keys":     stdlib.KeysFunc,
+		"values":   stdlib.ValuesFunc,
+		"lookup":   stdlib.LookupFunc,
+		"contains": stdlib.ContainsFunc,
+		"element":  stdlib.ElementFunc,
+		"flatten":  stdlib.FlattenFunc,
+		"distinct": stdlib.DistinctFunc,
+	}
+}

--- a/pkg/analysis/stdlib/stdlib_test.go
+++ b/pkg/analysis/stdlib/stdlib_test.go
@@ -1,0 +1,228 @@
+package stdlib_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/dgr237/tflens/pkg/analysis/stdlib"
+)
+
+// stdlibCase pairs a fixture name with the cty.Value the local
+// `out = <expr>` should evaluate to. Per-function fixtures live
+// under pkg/analysis/stdlib/testdata/<Name>/main.tf — exactly one
+// `locals { out = <expr> }` block apiece.
+//
+// The driver loads the fixture, evaluates the local's expression
+// against an EvalContext that has only stdlib.Functions() wired in
+// (no module variables or other locals), and compares the result
+// against Want via cty.Value.RawEquals — exact-equality including
+// type, so a list-vs-set or string-vs-number mismatch fails.
+type stdlibCase struct {
+	Name string
+	Want cty.Value
+}
+
+func TestStdlibFunctionCases(t *testing.T) {
+	for _, tc := range stdlibCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			got := evalFixtureLocal(t, tc.Name)
+			if !got.RawEquals(tc.Want) {
+				t.Errorf("%s: got %#v, want %#v", tc.Name, got, tc.Want)
+			}
+		})
+	}
+}
+
+var stdlibCases = []stdlibCase{
+	// Type conversion
+	{
+		Name: "toset",
+		Want: cty.SetVal([]cty.Value{cty.StringVal("us-east-1"), cty.StringVal("us-west-2")}),
+	},
+	{
+		Name: "tolist",
+		// tolist of a set returns the set's elements in cty's set
+		// iteration order, which sorts strings lexicographically.
+		Want: cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c")}),
+	},
+	{
+		Name: "tomap",
+		Want: cty.MapVal(map[string]cty.Value{
+			"k1": cty.StringVal("v1"), "k2": cty.StringVal("v2"),
+		}),
+	},
+	{
+		Name: "tostring",
+		Want: cty.StringVal("42"),
+	},
+	{
+		Name: "tonumber",
+		Want: cty.NumberIntVal(42),
+	},
+	{
+		Name: "tobool",
+		Want: cty.True,
+	},
+
+	// Collections
+	{
+		Name: "length",
+		Want: cty.NumberIntVal(4),
+	},
+	{
+		// concat of tuple literals returns a tuple, not a list — the
+		// inputs are typed as tuples by the HCL literal-typer because
+		// they could (in principle) hold heterogeneous types.
+		Name: "concat",
+		Want: cty.TupleVal([]cty.Value{
+			cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c"),
+			cty.StringVal("d"), cty.StringVal("e"),
+		}),
+	},
+	{
+		Name: "merge",
+		// merge of two single-key object literals yields an object
+		// (not a map) whose attribute set is the union of the inputs.
+		Want: cty.ObjectVal(map[string]cty.Value{
+			"a": cty.NumberIntVal(1), "b": cty.NumberIntVal(2),
+		}),
+	},
+	{
+		// Later argument wins on overlap — Terraform-spec behaviour.
+		Name: "merge_overlapping_keys",
+		Want: cty.ObjectVal(map[string]cty.Value{"k": cty.StringVal("last")}),
+	},
+	{
+		// keys of an OBJECT (HCL { "z" = 1, ... } literal) returns a
+		// tuple sorted lexicographically by key. keys of a MAP would
+		// return a list — see the `keys` of `tomap(...)` case in a
+		// future batch if we need to pin both shapes.
+		Name: "keys",
+		Want: cty.TupleVal([]cty.Value{
+			cty.StringVal("a"), cty.StringVal("m"), cty.StringVal("z"),
+		}),
+	},
+	{
+		// values follows the same sort-by-key ordering as keys, so
+		// values[i] corresponds to keys[i]. Returns a tuple here for
+		// the same object-vs-map reason as keys.
+		Name: "values",
+		Want: cty.TupleVal([]cty.Value{
+			cty.StringVal("A"), cty.StringVal("M"), cty.StringVal("Z"),
+		}),
+	},
+	{
+		Name: "lookup_present",
+		Want: cty.StringVal("v"),
+	},
+	{
+		Name: "lookup_default",
+		Want: cty.StringVal("fallback"),
+	},
+	{
+		Name: "contains_true",
+		Want: cty.True,
+	},
+	{
+		Name: "contains_false",
+		Want: cty.False,
+	},
+	{
+		Name: "element",
+		Want: cty.StringVal("b"),
+	},
+	{
+		// flatten of nested tuple literals returns a tuple — the
+		// outer-vs-inner type promotion to list only happens when
+		// every nested element shares one type AND the outer was a
+		// list to begin with.
+		Name: "flatten",
+		Want: cty.TupleVal([]cty.Value{
+			cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c"),
+			cty.StringVal("d"), cty.StringVal("e"),
+		}),
+	},
+	{
+		Name: "distinct",
+		Want: cty.ListVal([]cty.Value{
+			cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c"),
+		}),
+	},
+}
+
+// TestFunctionsReturnsExpectedSet pins the public surface — the
+// curated function set declared in this batch. Adding a new function
+// requires updating both the map AND this test.
+func TestFunctionsReturnsExpectedSet(t *testing.T) {
+	want := []string{
+		"toset", "tolist", "tomap", "tostring", "tonumber", "tobool",
+		"length", "concat", "merge", "keys", "values",
+		"lookup", "contains", "element", "flatten", "distinct",
+	}
+	got := stdlib.Functions()
+	if len(got) != len(want) {
+		t.Errorf("Functions() len = %d, want %d", len(got), len(want))
+	}
+	for _, name := range want {
+		if _, ok := got[name]; !ok {
+			t.Errorf("missing function %q in Functions()", name)
+		}
+	}
+}
+
+// TestFunctionsReturnsFreshMap confirms the per-call freshness
+// contract — mutating the returned map must not affect a subsequent
+// call. This lets tests swap implementations safely.
+func TestFunctionsReturnsFreshMap(t *testing.T) {
+	first := stdlib.Functions()
+	delete(first, "length")
+	second := stdlib.Functions()
+	if _, ok := second["length"]; !ok {
+		t.Error("Functions() should return a fresh map; mutation leaked across calls")
+	}
+}
+
+// ---- helpers ----
+
+// evalFixtureLocal loads pkg/analysis/stdlib/testdata/<name>/main.tf,
+// finds the `locals { out = <expr> }` block, and evaluates `out`
+// against an EvalContext containing only stdlib.Functions() — no
+// variables, no other locals. Returns the evaluated cty.Value.
+func evalFixtureLocal(t *testing.T, name string) cty.Value {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	src, err := os.ReadFile(filepath.Join(filepath.Dir(file), "testdata", name, "main.tf"))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	p := hclparse.NewParser()
+	f, diags := p.ParseHCL(src, "main.tf")
+	if diags.HasErrors() {
+		t.Fatalf("parse %s: %v", name, diags)
+	}
+	body := f.Body.(*hclsyntax.Body)
+	for _, block := range body.Blocks {
+		if block.Type != "locals" {
+			continue
+		}
+		attr, ok := block.Body.Attributes["out"]
+		if !ok {
+			continue
+		}
+		ctx := &hcl.EvalContext{Functions: stdlib.Functions()}
+		v, diags := attr.Expr.Value(ctx)
+		if diags.HasErrors() {
+			t.Fatalf("evaluating %s.out: %v", name, diags)
+		}
+		return v
+	}
+	t.Fatalf("fixture %s missing `locals { out = ... }` block", name)
+	return cty.NilVal
+}

--- a/pkg/analysis/stdlib/testdata/concat/main.tf
+++ b/pkg/analysis/stdlib/testdata/concat/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = concat(["a", "b"], ["c"], ["d", "e"])
+}

--- a/pkg/analysis/stdlib/testdata/contains_false/main.tf
+++ b/pkg/analysis/stdlib/testdata/contains_false/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = contains(["a", "b", "c"], "z")
+}

--- a/pkg/analysis/stdlib/testdata/contains_true/main.tf
+++ b/pkg/analysis/stdlib/testdata/contains_true/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = contains(["a", "b", "c"], "b")
+}

--- a/pkg/analysis/stdlib/testdata/distinct/main.tf
+++ b/pkg/analysis/stdlib/testdata/distinct/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = distinct(["a", "b", "a", "c", "b"])
+}

--- a/pkg/analysis/stdlib/testdata/element/main.tf
+++ b/pkg/analysis/stdlib/testdata/element/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = element(["a", "b", "c"], 1)
+}

--- a/pkg/analysis/stdlib/testdata/flatten/main.tf
+++ b/pkg/analysis/stdlib/testdata/flatten/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = flatten([["a", "b"], ["c"], ["d", "e"]])
+}

--- a/pkg/analysis/stdlib/testdata/keys/main.tf
+++ b/pkg/analysis/stdlib/testdata/keys/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = keys({ "z" = 1, "a" = 2, "m" = 3 })
+}

--- a/pkg/analysis/stdlib/testdata/length/main.tf
+++ b/pkg/analysis/stdlib/testdata/length/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = length(["a", "b", "c", "d"])
+}

--- a/pkg/analysis/stdlib/testdata/lookup_default/main.tf
+++ b/pkg/analysis/stdlib/testdata/lookup_default/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = lookup({ "k" = "v" }, "missing", "fallback")
+}

--- a/pkg/analysis/stdlib/testdata/lookup_present/main.tf
+++ b/pkg/analysis/stdlib/testdata/lookup_present/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = lookup({ "k" = "v" }, "k", "fallback")
+}

--- a/pkg/analysis/stdlib/testdata/merge/main.tf
+++ b/pkg/analysis/stdlib/testdata/merge/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = merge({ "a" = 1 }, { "b" = 2 })
+}

--- a/pkg/analysis/stdlib/testdata/merge_overlapping_keys/main.tf
+++ b/pkg/analysis/stdlib/testdata/merge_overlapping_keys/main.tf
@@ -1,0 +1,4 @@
+locals {
+  # Later argument wins on overlap — Terraform-spec behaviour.
+  out = merge({ "k" = "first" }, { "k" = "last" })
+}

--- a/pkg/analysis/stdlib/testdata/tobool/main.tf
+++ b/pkg/analysis/stdlib/testdata/tobool/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = tobool("true")
+}

--- a/pkg/analysis/stdlib/testdata/tolist/main.tf
+++ b/pkg/analysis/stdlib/testdata/tolist/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = tolist(toset(["a", "b", "c"]))
+}

--- a/pkg/analysis/stdlib/testdata/tomap/main.tf
+++ b/pkg/analysis/stdlib/testdata/tomap/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = tomap({ "k1" = "v1", "k2" = "v2" })
+}

--- a/pkg/analysis/stdlib/testdata/tonumber/main.tf
+++ b/pkg/analysis/stdlib/testdata/tonumber/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = tonumber("42")
+}

--- a/pkg/analysis/stdlib/testdata/toset/main.tf
+++ b/pkg/analysis/stdlib/testdata/toset/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = toset(["us-east-1", "us-west-2", "us-east-1"])
+}

--- a/pkg/analysis/stdlib/testdata/tostring/main.tf
+++ b/pkg/analysis/stdlib/testdata/tostring/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = tostring(42)
+}

--- a/pkg/analysis/stdlib/testdata/values/main.tf
+++ b/pkg/analysis/stdlib/testdata/values/main.tf
@@ -1,0 +1,4 @@
+locals {
+  # values returns in key-sorted order, NOT insertion order.
+  out = values({ "z" = "Z", "a" = "A", "m" = "M" })
+}

--- a/pkg/analysis/tracked.go
+++ b/pkg/analysis/tracked.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/dgr237/tflens/pkg/analysis/stdlib"
 	"github.com/dgr237/tflens/pkg/token"
 )
 
@@ -404,20 +405,28 @@ func (m *Module) LookupAttrText(entityID, attrName string) (string, bool) {
 }
 
 // EvalContext returns an hcl.EvalContext populated with this module's
-// statically-evaluable variable defaults and local values, suitable
+// statically-evaluable variable defaults and local values, plus the
+// curated Terraform-stdlib function set from tfStdlib(). Suitable
 // for hclsyntax expression evaluation. Variables and locals whose
 // values can't be evaluated cleanly (no default, references a
-// Terraform-specific function we don't wire in, etc.) are simply
+// Terraform function not in the curated set, etc.) are simply
 // omitted — callers that try to evaluate an expression touching them
 // get a diagnostic and can fall back to text comparison.
 //
-// No Terraform stdlib functions (length, contains, keys, merge, …)
-// are wired in; only the cty stdlib is available. This is deliberate:
-// the use case is "did the effective value change?" and getting that
+// The Terraform-stdlib functions wired in cover type conversion
+// (toset/tolist/tomap/tostring/tonumber/tobool) and core collection
+// operations (length/concat/merge/keys/values/lookup/contains/element/
+// flatten/distinct). Filesystem (file, templatefile), non-deterministic
+// (timestamp, uuid), and complex-semantics (can, try) functions stay
+// out by design — see tfStdlib's comment for the rationale. The use
+// case is "did the effective value change?" and getting that
 // answer right for ternaries / arithmetic / string interpolation is
 // enough to suppress the most common class of false positive.
 func (m *Module) EvalContext() *hcl.EvalContext {
-	ctx := &hcl.EvalContext{Variables: map[string]cty.Value{}}
+	ctx := &hcl.EvalContext{
+		Variables: map[string]cty.Value{},
+		Functions: stdlib.Functions(),
+	}
 	if m == nil {
 		return ctx
 	}

--- a/pkg/diff/testdata/tracked_eval_length_change_breaking/new.tf
+++ b/pkg/diff/testdata/tracked_eval_length_change_breaking/new.tf
@@ -1,0 +1,7 @@
+locals {
+  # An element was actually added — concat result has 4 elements
+  # instead of 3. Must still be Breaking despite both sides going
+  # through concat(). Pin so the new value-equivalent short-circuit
+  # doesn't accidentally over-suppress real changes.
+  ids = concat(["a", "b"], ["c", "d"]) # tflens:track: instance set — additions destroy state
+}

--- a/pkg/diff/testdata/tracked_eval_length_change_breaking/old.tf
+++ b/pkg/diff/testdata/tracked_eval_length_change_breaking/old.tf
@@ -1,0 +1,3 @@
+locals {
+  ids = concat(["a", "b"], ["c"]) # tflens:track: instance set — additions destroy state
+}

--- a/pkg/diff/testdata/tracked_eval_merge_restructured/new.tf
+++ b/pkg/diff/testdata/tracked_eval_merge_restructured/new.tf
@@ -1,0 +1,5 @@
+locals {
+  # Restructured via merge() but the resulting object's key→value
+  # pairs are identical. Should be Informational, not Breaking.
+  tags = merge({ "env" = "prod" }, { "team" = "platform" }) # tflens:track: identity tags
+}

--- a/pkg/diff/testdata/tracked_eval_merge_restructured/old.tf
+++ b/pkg/diff/testdata/tracked_eval_merge_restructured/old.tf
@@ -1,0 +1,3 @@
+locals {
+  tags = { "env" = "prod", "team" = "platform" } # tflens:track: identity tags
+}

--- a/pkg/diff/testdata/tracked_eval_toset_reorder/new.tf
+++ b/pkg/diff/testdata/tracked_eval_toset_reorder/new.tf
@@ -1,0 +1,5 @@
+locals {
+  # Same effective set as old — toset folds the dupe and discards
+  # order. Should be Informational, not Breaking.
+  ids = toset(["c", "a", "b", "a"]) # tflens:track: source-of-truth instance set
+}

--- a/pkg/diff/testdata/tracked_eval_toset_reorder/old.tf
+++ b/pkg/diff/testdata/tracked_eval_toset_reorder/old.tf
@@ -1,0 +1,3 @@
+locals {
+  ids = toset(["a", "b", "c"]) # tflens:track: source-of-truth instance set
+}

--- a/pkg/diff/tracked.go
+++ b/pkg/diff/tracked.go
@@ -445,7 +445,12 @@ func equivalentByEval(oldText, newText string, oldCtx, newCtx *hcl.EvalContext) 
 	if !ok {
 		return false
 	}
-	return oldVal.RawEquals(newVal)
+	// ValueEquivalent (rather than RawEquals) so the new stdlib-
+	// function evaluation path doesn't trigger false positives when
+	// it produces a List on one side and a Tuple on the other —
+	// e.g. distinct(["a","b"]) vs ["a","b"]. Both are equivalent for
+	// downstream Terraform behaviour.
+	return analysis.ValueEquivalent(oldVal, newVal)
 }
 
 // tryEvalText parses text as an hcl expression and evaluates it in

--- a/pkg/diff/tracked_test.go
+++ b/pkg/diff/tracked_test.go
@@ -227,6 +227,35 @@ func TestDiffTrackedCases(t *testing.T) {
 
 var trackedCases = []trackedCase{
 	{
+		// Stdlib batch 1 (toset): old + new produce the same effective
+		// set via different toset() input shapes. Texts differ but the
+		// evaluated values match → Informational, not Breaking.
+		Name:           "tracked_eval_toset_reorder",
+		Subject:        "local.ids.value",
+		WantKind:       diff.Informational,
+		DetailContains: []string{"no effective value change"},
+	},
+	{
+		// Stdlib batch 1 (merge): the new side restructures the same
+		// key/value pairs across two merge() arguments. Effective
+		// object identical → Informational.
+		Name:           "tracked_eval_merge_restructured",
+		Subject:        "local.tags.value",
+		WantKind:       diff.Informational,
+		DetailContains: []string{"no effective value change"},
+	},
+	{
+		// Stdlib batch 1 (concat true positive): both sides go through
+		// concat() but the new side adds an element. The evaluated
+		// values legitimately differ → still Breaking. Pin so the new
+		// value-equivalent short-circuit doesn't over-suppress real
+		// changes.
+		Name:           "tracked_eval_length_change_breaking",
+		Subject:        "local.ids.value",
+		WantKind:       diff.Breaking,
+		DetailContains: []string{"value"},
+	},
+	{
 		Name:           "tracked_literal_value_changed",
 		Subject:        "resource.aws_eks_cluster.this.cluster_version",
 		WantKind:       diff.Breaking,

--- a/pkg/statediff/effective_value_test.go
+++ b/pkg/statediff/effective_value_test.go
@@ -1,0 +1,85 @@
+package statediff_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/dgr237/tflens/pkg/loader"
+	"github.com/dgr237/tflens/pkg/statediff"
+)
+
+// effectiveValueCase pairs an old/new fixture pair under
+// pkg/statediff/testdata/effective_value_collapse/<Name>/{main,feature}/main.tf
+// with an assertion on whether the change should be flagged. The
+// new value-equality short-circuit in diffValues collapses text-
+// different / value-identical sensitive locals; these tests pin
+// both directions:
+//
+//   - WantFlagged=false: text differs but the cty.Value is identical
+//     (sort, distinct on already-sorted, merge, toset reorder) →
+//     suppressed, no SensitiveChange emitted.
+//   - WantFlagged=true: the value actually changed (length up/down,
+//     element added/removed) → still flagged. Pin so the new
+//     short-circuit doesn't accidentally over-suppress.
+type effectiveValueCase struct {
+	Name        string
+	WantFlagged bool
+}
+
+func TestStatediffEffectiveValueCollapse(t *testing.T) {
+	for _, tc := range effectiveValueCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			oldP := loadEffectiveValueFixture(t, tc.Name, "main")
+			newP := loadEffectiveValueFixture(t, tc.Name, "feature")
+			r := statediff.Analyze(oldP, newP, nil)
+			if tc.WantFlagged && len(r.SensitiveChanges) == 0 {
+				t.Errorf("expected SensitiveChange to fire; got none")
+			}
+			if !tc.WantFlagged && len(r.SensitiveChanges) != 0 {
+				t.Errorf("expected no SensitiveChange (text differs but value matches); got: %+v",
+					r.SensitiveChanges)
+			}
+		})
+	}
+}
+
+var effectiveValueCases = []effectiveValueCase{
+	{
+		// Both branches define the same effective list value via
+		// different expressions (literal vs distinct-of-already-
+		// distinct). New value-equality check suppresses.
+		Name: "sort_doesnt_flag",
+	},
+	{
+		// toset() folds duplicates and discards order. Text is
+		// noisily different but the resulting set is identical.
+		Name: "toset_reorder_doesnt_flag",
+	},
+	{
+		// merge() across multiple objects with the same key/value
+		// pairs as the original literal — equivalent object value.
+		Name: "merge_same_value_doesnt_flag",
+	},
+	{
+		// True positive: an element was actually added. Confirm
+		// the suppression doesn't over-fire.
+		Name:        "length_change_still_flags",
+		WantFlagged: true,
+	},
+}
+
+func loadEffectiveValueFixture(t *testing.T, caseName, side string) *loader.Project {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Join(filepath.Dir(file), "testdata", "effective_value_collapse", caseName, side)
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("fixture %s/%s missing: %v", caseName, side, err)
+	}
+	p, _, err := loader.LoadProject(dir)
+	if err != nil {
+		t.Fatalf("LoadProject(%s/%s): %v", caseName, side, err)
+	}
+	return p
+}

--- a/pkg/statediff/statediff.go
+++ b/pkg/statediff/statediff.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/dgr237/tflens/pkg/analysis"
 	"github.com/dgr237/tflens/pkg/loader"
@@ -323,21 +324,37 @@ func collectSensitiveCandidates(oldMod, newMod *analysis.Module) []valueChange {
 	return out
 }
 
-func diffValues(kind string, oldV, newV map[string]string) []valueChange {
+// diffValues pairs same-named entries from oldV and newV and emits
+// one valueChange per real difference. Comparison is text-first
+// (cheap, conservative); when texts differ but BOTH sides evaluated
+// to a cty.Value cleanly, value equality is the tiebreaker — text-
+// different / value-identical pairs are suppressed (e.g. a literal
+// list compared to sort() of the same elements).
+//
+// When evaluation isn't possible on either side (references
+// something outside the EvalContext, uses an out-of-stdlib function),
+// the value-equality check is skipped and the conservative text-only
+// behaviour applies. That keeps the false-positive bias intact for
+// expressions tflens can't reason about statically.
+func diffValues(kind string, oldV, newV map[string]valueRef) []valueChange {
 	var out []valueChange
-	for name, oldText := range oldV {
-		newText, ok := newV[name]
+	for name, old := range oldV {
+		neu, ok := newV[name]
 		if !ok {
-			out = append(out, valueChange{kind: kind, name: name, oldText: oldText})
+			out = append(out, valueChange{kind: kind, name: name, oldText: old.text})
 			continue
 		}
-		if oldText != newText {
-			out = append(out, valueChange{kind: kind, name: name, oldText: oldText, newText: newText})
+		if old.text == neu.text {
+			continue
 		}
+		if old.ok && neu.ok && analysis.ValueEquivalent(old.val, neu.val) {
+			continue
+		}
+		out = append(out, valueChange{kind: kind, name: name, oldText: old.text, newText: neu.text})
 	}
-	for name, newText := range newV {
+	for name, neu := range newV {
 		if _, ok := oldV[name]; !ok {
-			out = append(out, valueChange{kind: kind, name: name, newText: newText})
+			out = append(out, valueChange{kind: kind, name: name, newText: neu.text})
 		}
 	}
 	return out
@@ -398,32 +415,60 @@ func mergeSensitive(out *[]SensitiveChange, modPath string, cand valueChange, r 
 	})
 }
 
-func localsMap(m *analysis.Module) map[string]string {
-	out := map[string]string{}
+// valueRef pairs an expression's canonical text with its
+// statically-evaluated cty.Value (when evaluation succeeds). The
+// text is what diffValues compares first; the value enables a
+// secondary equality check that suppresses false positives when
+// text differs but the effective value doesn't (e.g.
+// `["a","b"]` vs `sort(["b","a"])`).
+//
+// ok is false when the expression couldn't be evaluated cleanly —
+// references something not in the EvalContext, uses a Terraform
+// function not in the curated stdlib set, etc. In that case
+// diffValues falls back to text-only comparison (the conservative
+// path: flag the change if texts differ).
+type valueRef struct {
+	text string
+	val  cty.Value
+	ok   bool
+}
+
+func localsMap(m *analysis.Module) map[string]valueRef {
+	out := map[string]valueRef{}
 	if m == nil {
 		return out
 	}
+	ctx := m.EvalContext()
 	for _, e := range m.Filter(analysis.KindLocal) {
-		if e.LocalExpr == nil {
-			out[e.Name] = ""
-			continue
+		ref := valueRef{}
+		if e.LocalExpr != nil {
+			ref.text = e.LocalExpr.Text()
+			if v, diags := e.LocalExpr.E.Value(ctx); !diags.HasErrors() {
+				ref.val = v
+				ref.ok = true
+			}
 		}
-		out[e.Name] = e.LocalExpr.Text()
+		out[e.Name] = ref
 	}
 	return out
 }
 
-func variableDefaultsMap(m *analysis.Module) map[string]string {
-	out := map[string]string{}
+func variableDefaultsMap(m *analysis.Module) map[string]valueRef {
+	out := map[string]valueRef{}
 	if m == nil {
 		return out
 	}
+	ctx := m.EvalContext()
 	for _, e := range m.Filter(analysis.KindVariable) {
-		if e.DefaultExpr == nil {
-			out[e.Name] = ""
-			continue
+		ref := valueRef{}
+		if e.DefaultExpr != nil {
+			ref.text = e.DefaultExpr.Text()
+			if v, diags := e.DefaultExpr.E.Value(ctx); !diags.HasErrors() {
+				ref.val = v
+				ref.ok = true
+			}
 		}
-		out[e.Name] = e.DefaultExpr.Text()
+		out[e.Name] = ref
 	}
 	return out
 }

--- a/pkg/statediff/testdata/effective_value_collapse/length_change_still_flags/feature/main.tf
+++ b/pkg/statediff/testdata/effective_value_collapse/length_change_still_flags/feature/main.tf
@@ -1,0 +1,11 @@
+locals {
+  # The set ACTUALLY changes — "c" added. Must still be flagged
+  # despite text-vs-value ambiguity in other parts of the
+  # expression. Pin the true-positive case so the new value-
+  # equality short-circuit doesn't over-suppress.
+  ids = toset(["a", "b", "c"])
+}
+
+resource "aws_instance" "web" {
+  for_each = local.ids
+}

--- a/pkg/statediff/testdata/effective_value_collapse/length_change_still_flags/main/main.tf
+++ b/pkg/statediff/testdata/effective_value_collapse/length_change_still_flags/main/main.tf
@@ -1,0 +1,7 @@
+locals {
+  ids = toset(["a", "b"])
+}
+
+resource "aws_instance" "web" {
+  for_each = local.ids
+}

--- a/pkg/statediff/testdata/effective_value_collapse/merge_same_value_doesnt_flag/feature/main.tf
+++ b/pkg/statediff/testdata/effective_value_collapse/merge_same_value_doesnt_flag/feature/main.tf
@@ -1,0 +1,9 @@
+locals {
+  # merge() of the same key/value pairs as main, just split across
+  # two argument objects. Effective object is identical → no flag.
+  tags = merge({ "env" = "prod" }, { "team" = "platform" })
+}
+
+resource "aws_instance" "web" {
+  for_each = local.tags
+}

--- a/pkg/statediff/testdata/effective_value_collapse/merge_same_value_doesnt_flag/main/main.tf
+++ b/pkg/statediff/testdata/effective_value_collapse/merge_same_value_doesnt_flag/main/main.tf
@@ -1,0 +1,7 @@
+locals {
+  tags = { "env" = "prod", "team" = "platform" }
+}
+
+resource "aws_instance" "web" {
+  for_each = local.tags
+}

--- a/pkg/statediff/testdata/effective_value_collapse/sort_doesnt_flag/feature/main.tf
+++ b/pkg/statediff/testdata/effective_value_collapse/sort_doesnt_flag/feature/main.tf
@@ -1,0 +1,9 @@
+locals {
+  # Same effective value as main — distinct() of an already-distinct
+  # tuple returns the same tuple. Text differs; value doesn't.
+  regions = distinct(["us-east-1", "us-west-2"])
+}
+
+resource "aws_instance" "web" {
+  for_each = toset(local.regions)
+}

--- a/pkg/statediff/testdata/effective_value_collapse/sort_doesnt_flag/main/main.tf
+++ b/pkg/statediff/testdata/effective_value_collapse/sort_doesnt_flag/main/main.tf
@@ -1,0 +1,7 @@
+locals {
+  regions = ["us-east-1", "us-west-2"]
+}
+
+resource "aws_instance" "web" {
+  for_each = toset(local.regions)
+}

--- a/pkg/statediff/testdata/effective_value_collapse/toset_reorder_doesnt_flag/feature/main.tf
+++ b/pkg/statediff/testdata/effective_value_collapse/toset_reorder_doesnt_flag/feature/main.tf
@@ -1,0 +1,9 @@
+locals {
+  # Source list is reordered + has a duplicate; toset() folds both
+  # away. Effective set is the same as main → no SensitiveChange.
+  ids = toset(["c", "a", "b", "a"])
+}
+
+resource "aws_instance" "web" {
+  for_each = local.ids
+}

--- a/pkg/statediff/testdata/effective_value_collapse/toset_reorder_doesnt_flag/main/main.tf
+++ b/pkg/statediff/testdata/effective_value_collapse/toset_reorder_doesnt_flag/main/main.tf
@@ -1,0 +1,7 @@
+locals {
+  ids = toset(["a", "b", "c"])
+}
+
+resource "aws_instance" "web" {
+  for_each = local.ids
+}


### PR DESCRIPTION
## Summary

- New `pkg/analysis/stdlib` subpackage exposes `Functions()` returning a curated 16-function set from `cty/function/stdlib`: 6 type-conversion (`toset`, `tolist`, `tomap`, `tostring`, `tonumber`, `tobool`) + 10 core collection (`length`, `concat`, `merge`, `keys`, `values`, `lookup`, `contains`, `element`, `flatten`, `distinct`). Wired into `Module.EvalContext`.
- Tracked-attribute diff (`pkg/diff/tracked.go`) and sensitive-local detection (`pkg/statediff`) now suppress false positives when text differs but the evaluated value matches — e.g. `["a","b"]` vs `distinct(["a","b"])` no longer flags. New `analysis.ValueEquivalent` bridges cty's strict Tuple↔List↔Set distinction via JSON marshalling.
- Closes #16 (batch 1).

## Test plan

- [x] `go test ./...` — all packages pass
- [x] 19 per-function table tests under `pkg/analysis/stdlib/testdata/<func>/main.tf`
- [x] 4 end-to-end statediff suppression cases under `pkg/statediff/testdata/effective_value_collapse/<case>/{main,feature}/main.tf` (incl. `length_change_still_flags` true-positive guard)
- [x] 3 tracked-attribute end-to-end cases under `pkg/diff/testdata/tracked_eval_*` (toset reorder, merge restructured, length change)