### PR TITLE
feat: stdlib batch 2 — string, numeric + extended collection helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to tflens are documented here. The format is loosely based o
 
 ## [Unreleased]
 
+### Changed
+
+- **Terraform stdlib functions: batch 2 (string, numeric + extended collection helpers).** `pkg/analysis/stdlib.Functions()` now wires in 30 more Terraform built-ins on top of batch 1's 16, bringing the curated set to 46. Strings (13): `upper`, `lower`, `title`, `join`, `split`, `format`, `formatlist`, `replace`, `trim`, `trimspace`, `trimprefix`, `trimsuffix`, `chomp`, `indent`, `substr`. Numeric (6): `abs`, `min`, `max`, `floor`, `ceil`, `pow`. Extended collections (9): `sort`, `reverse`, `slice`, `chunklist`, `compact`, `coalesce`, `coalescelist`, `zipmap`, `range`. The same effective-value-collapse machinery introduced in batch 1 now suppresses false positives for these too — a tracked attribute or sensitive local that switches between e.g. `"us-east-1"` and `lower("US-EAST-1")`, `["a","b","c"]` and `sort(["c","b","a"])`, or `"ec2-small-v3"` and `format("ec2-%s-v%d", "small", 3)`, no longer flags as a change. Two functions needed Terraform-faithful wrappers because cty's defaults diverge: `replace` (`pkg/analysis/stdlib/replace.go`) — Terraform dispatches on `/regex/`-delimited search args, while cty's `ReplaceFunc` is literal-only; and `coalesce` (`pkg/analysis/stdlib/coalesce.go`) — Terraform's `coalesce` skips empty strings as well as nulls, while cty's only skips nulls. New per-function table tests under `pkg/analysis/stdlib/testdata/<func>/main.tf` (30 new fixtures, plus `replace_literal`/`replace_regex` and 4 negative-path coalesce/replace error cases), end-to-end statediff suppression cases under `pkg/statediff/testdata/effective_value_collapse/{lower,format}_collapses/{main,feature}/main.tf`, and end-to-end tracked-attribute cases under `pkg/diff/testdata/tracked_eval_{lower,format}_collapses/`. `pkg/analysis/stdlib` package coverage at 100%.
+
 ## [0.3.0] — 2026-04-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Exit code is 1 when any resource add/remove or sensitive local fires.
 ### What it does not do
 
 - **Plan simulation.** Attribute-level diffs (`cidr_block = "10.0.0.0/16"` → `"10.1.0.0/16"`) need provider schemas and expression evaluation — that is `terraform plan`'s job. `statediff` is a complementary, cheap, schema-free check that catches a different class of hazard than plan.
-- **Full expression evaluation.** A sensitive local with `count = length(local.xs) > 0 ? 1 : 0` is flagged as "may change" without us knowing whether `length` actually crosses the boundary. The signal is a warning, not a definitive answer.
+- **Full expression evaluation.** A curated subset of Terraform built-ins is wired in (see [Static evaluation surface](#static-evaluation-surface) below), so e.g. `count = length(local.xs)` IS evaluated when `local.xs` is statically known. But anything that reaches a data source, a computed resource attribute, or a non-curated function still falls back to "may change". The signal is a warning, not a definitive answer.
 - **Variable-driven changes across module callers.** A `count = var.n` resource where the caller on one branch passes `n = 3` and the other passes `n = 1` is not currently followed across module boundaries.
 
 ## Tracked attributes (for application-development teams)
@@ -460,7 +460,7 @@ Pick the highest-leverage spot for your scenario:
 
 **Effective-value awareness:** when the literal text of an expression changes but it evaluates to the same constant (e.g. `"1.34"` on the old side vs `var.upgrade ? "1.35" : "1.34"` with `var.upgrade = false` on the new side, both yielding `"1.34"`), the diff suppresses the value-change detail. The marker still surfaces *what's new* (a freshly-referenced variable, for example) as Informational supporting context — useful for reviewers to know what's wired in — but won't gate CI as Breaking unless the effective value actually moved.
 
-Evaluation goes through known variable defaults and local values via the cty stdlib. Expressions that can't be evaluated statically — references to `data.X.Y` data sources, computed resource attributes (`aws_vpc.main.id`), Terraform-specific functions (`length`, `contains`, `keys`, `merge`, `lookup`, …) — fall back to literal text comparison. That fallback is conservative: if the texts differ, the diff is reported as Breaking even when the *real* value might be unchanged, because tflens can't prove either way without resolving the unevaluable bits. Expressions where text and effective value both differ on the new side are always reported correctly; expressions where text differs but value doesn't are only collapsed when both sides evaluate cleanly.
+Evaluation goes through known variable defaults and local values via the cty stdlib plus a curated set of ~46 Terraform built-ins (`length`, `contains`, `merge`, `lookup`, `concat`, `toset`, `lower`, `format`, `replace`, `sort`, `coalesce`, `min`/`max`, … — see [Static evaluation surface](#static-evaluation-surface) for the full list and what's deliberately out). Expressions that can't be evaluated statically — references to `data.X.Y` data sources, computed resource attributes (`aws_vpc.main.id`), or any non-curated function — fall back to literal text comparison. That fallback is conservative: if the texts differ, the diff is reported as Breaking even when the *real* value might be unchanged, because tflens can't prove either way without resolving the unevaluable bits. Expressions where text and effective value both differ on the new side are always reported correctly; expressions where text differs but value doesn't are only collapsed when both sides evaluate cleanly.
 
 ### Where it works
 
@@ -524,9 +524,24 @@ These are not bugs but deliberate boundaries:
 
 - **No Terraform execution.** This is a static analyser. Anything that requires planning, applying, or querying a provider is out of scope.
 - **No provider schemas.** We do not embed AWS/GCP/Azure/etc. provider schemas. Resource attribute types, required-vs-optional attributes, and deprecations of resource types are invisible to us. Running `terraform validate` in addition to this tool catches those.
-- **No expression evaluation.** Functions, conditionals, and references to computed attributes cannot be resolved statically. The inferred type of `aws_vpc.main.id` is `TypeUnknown`. The tracked-attribute pass does follow `var.X` / `local.X` references one or two hops deep — by comparing the canonical *text* of the referenced default or value, not by evaluating the expression.
+- **Limited expression evaluation.** Conditionals, arithmetic, string interpolation, and a curated set of ~46 Terraform built-in functions (see [Static evaluation surface](#static-evaluation-surface)) ARE evaluated when every reference resolves to a known constant — this powers the effective-value-collapse for tracked attributes and statediff sensitive locals. Anything that reaches a computed attribute (`aws_vpc.main.id` is always `TypeUnknown`), a data source, or a non-curated function (`templatefile`, `jsondecode`, `regex`, `try`, …) falls back to text comparison.
 - **Caller awareness only at module-call boundaries.** `whatif` and the local-source path of `diff` cross-validate a parent module's `module "x" { ... }` block against the candidate child's variables and outputs. Beyond that — e.g. whether some external repo that pinned to an old version still works after a registry-module change — is out of scope; we'd need to analyse those callers too.
 - **Mid-expression comments are dropped.** Line and block comments at statement boundaries round-trip correctly; comments embedded inside a function call argument list split across lines, or inside a multi-line object/tuple literal, are lost by `fmt`.
+
+### Static evaluation surface
+
+Tracked-attribute diffs and statediff sensitive-local detection both ask the question "does the new expression evaluate to the same value as the old one?". When the answer is yes, the change is suppressed — so a refactor like `"us-east-1"` → `lower("US-EAST-1")` doesn't gate CI.
+
+The curated function set is intentionally a subset of Terraform's built-ins, not a complete mirror. Adding more is cheap (one entry in `pkg/analysis/stdlib/stdlib.go` plus a fixture) — see [issue #16](https://github.com/dgr237/tflens/issues/16) for the rationale on what's in vs. out.
+
+| Group | Functions |
+| --- | --- |
+| Type conversion | `toset`, `tolist`, `tomap`, `tostring`, `tonumber`, `tobool` |
+| Collections | `length`, `concat`, `merge`, `keys`, `values`, `lookup`, `contains`, `element`, `flatten`, `distinct`, `sort`, `reverse`, `slice`, `chunklist`, `compact`, `coalesce`, `coalescelist`, `zipmap`, `range` |
+| String | `upper`, `lower`, `title`, `join`, `split`, `format`, `formatlist`, `replace` (literal + `/regex/` dispatch), `trim`, `trimspace`, `trimprefix`, `trimsuffix`, `chomp`, `indent`, `substr` |
+| Numeric | `abs`, `min`, `max`, `floor`, `ceil`, `pow` |
+
+**Deliberately excluded** (and unlikely to be added): filesystem (`file`, `fileset`, `templatefile`) — needs filesystem context that isn't valid for static analysis; non-deterministic (`timestamp`, `uuid`, `bcrypt`) — must always return unknown; complex semantics (`can`, `try`) — needs full Terraform evaluator catch-and-retry. **Not yet wired but plausible** for future batches: `regex`/`regexall`/`regexreplace`, `jsondecode`/`jsonencode`, `formatdate`, `parseint`, `signum`, `log`.
 
 ## Editor integration
 

--- a/pkg/analysis/stdlib/coalesce.go
+++ b/pkg/analysis/stdlib/coalesce.go
@@ -1,0 +1,51 @@
+package stdlib
+
+import (
+	"errors"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// terraformCoalesceFunc mirrors Terraform's `coalesce(...)`, which
+// returns the first argument that is neither null NOR (for strings)
+// an empty string. cty's stdlib.CoalesceFunc only skips nulls, so a
+// direct wrap would diverge for the very common
+// `coalesce("", var.fallback)` idiom.
+var terraformCoalesceFunc = function.New(&function.Spec{
+	Params: []function.Parameter{},
+	VarParam: &function.Parameter{
+		Name:             "vals",
+		Type:             cty.DynamicPseudoType,
+		AllowUnknown:     true,
+		AllowDynamicType: true,
+		AllowNull:        true,
+	},
+	Type: func(args []cty.Value) (cty.Type, error) {
+		argTypes := make([]cty.Type, len(args))
+		for i, v := range args {
+			argTypes[i] = v.Type()
+		}
+		retType, _ := convert.UnifyUnsafe(argTypes)
+		if retType == cty.NilType {
+			return cty.NilType, errors.New("all arguments must have the same type")
+		}
+		return retType, nil
+	},
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		for _, v := range args {
+			if !v.IsKnown() {
+				return cty.UnknownVal(retType), nil
+			}
+			if v.IsNull() {
+				continue
+			}
+			if retType == cty.String && v.Type() == cty.String && v.AsString() == "" {
+				continue
+			}
+			return convert.Convert(v, retType)
+		}
+		return cty.NilVal, errors.New("no non-null, non-empty-string arguments")
+	},
+})

--- a/pkg/analysis/stdlib/replace.go
+++ b/pkg/analysis/stdlib/replace.go
@@ -1,0 +1,35 @@
+package stdlib
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// terraformReplaceFunc mirrors Terraform's `replace(str, substr, replace)`,
+// which dispatches on whether `substr` is a `/regex/`-delimited pattern.
+// cty's stdlib.ReplaceFunc is literal-only, so wrapping it directly would
+// silently produce wrong results for the regex form.
+var terraformReplaceFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{Name: "str", Type: cty.String},
+		{Name: "substr", Type: cty.String},
+		{Name: "replace", Type: cty.String},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		str := args[0].AsString()
+		substr := args[1].AsString()
+		replace := args[2].AsString()
+		if len(substr) > 1 && substr[0] == '/' && substr[len(substr)-1] == '/' {
+			re, err := regexp.Compile(substr[1 : len(substr)-1])
+			if err != nil {
+				return cty.UnknownVal(cty.String), err
+			}
+			return cty.StringVal(re.ReplaceAllString(str, replace)), nil
+		}
+		return cty.StringVal(strings.ReplaceAll(str, substr, replace)), nil
+	},
+})

--- a/pkg/analysis/stdlib/stdlib.go
+++ b/pkg/analysis/stdlib/stdlib.go
@@ -7,14 +7,20 @@
 // what's in vs. out. Adding a new batch of functions is a single
 // edit to Functions().
 //
-// All implementations come from cty/function/stdlib, which is the
+// Most implementations come from cty/function/stdlib, which is the
 // same library Terraform itself uses for these specific functions.
 // Wrapping them here means our evaluation behaviour matches
-// Terraform's exactly for the functions we cover. Functions that
-// would need filesystem access (file, fileset, templatefile),
-// non-deterministic state (timestamp, uuid, bcrypt), or full
-// evaluator catch-and-retry semantics (can, try) are intentionally
-// excluded so the curated set stays evaluation-pure.
+// Terraform's exactly for the functions we cover. The two exceptions
+// — `replace` and `coalesce` — diverge from cty's defaults: Terraform
+// dispatches `replace` on whether the search arg is `/regex/`-
+// delimited, and Terraform's `coalesce` skips empty strings, not just
+// nulls. See replace.go and coalesce.go for the wrappers that restore
+// Terraform's contract.
+//
+// Functions that would need filesystem access (file, fileset,
+// templatefile), non-deterministic state (timestamp, uuid, bcrypt),
+// or full evaluator catch-and-retry semantics (can, try) are
+// intentionally excluded so the curated set stays evaluation-pure.
 package stdlib
 
 import (
@@ -51,5 +57,45 @@ func Functions() map[string]function.Function {
 		"element":  stdlib.ElementFunc,
 		"flatten":  stdlib.FlattenFunc,
 		"distinct": stdlib.DistinctFunc,
+
+		// String functions. `replace` needs a Terraform-side wrapper
+		// because the literal-vs-regex dispatch (`/pattern/` triggers
+		// regex mode) lives above cty's literal-only ReplaceFunc.
+		"upper":      stdlib.UpperFunc,
+		"lower":      stdlib.LowerFunc,
+		"title":      stdlib.TitleFunc,
+		"join":       stdlib.JoinFunc,
+		"split":      stdlib.SplitFunc,
+		"format":     stdlib.FormatFunc,
+		"formatlist": stdlib.FormatListFunc,
+		"replace":    terraformReplaceFunc,
+		"trim":       stdlib.TrimFunc,
+		"trimspace":  stdlib.TrimSpaceFunc,
+		"trimprefix": stdlib.TrimPrefixFunc,
+		"trimsuffix": stdlib.TrimSuffixFunc,
+		"chomp":      stdlib.ChompFunc,
+		"indent":     stdlib.IndentFunc,
+		"substr":     stdlib.SubstrFunc,
+
+		// Additional collection helpers — same value-collapse story as
+		// the batch-1 collection functions; these are the next tier of
+		// commonly-used Terraform-stdlib pure functions.
+		"sort":         stdlib.SortFunc,
+		"reverse":      stdlib.ReverseListFunc,
+		"slice":        stdlib.SliceFunc,
+		"chunklist":    stdlib.ChunklistFunc,
+		"compact":      stdlib.CompactFunc,
+		"coalesce":     terraformCoalesceFunc,
+		"coalescelist": stdlib.CoalesceListFunc,
+		"zipmap":       stdlib.ZipmapFunc,
+		"range":        stdlib.RangeFunc,
+
+		// Numeric functions.
+		"abs":   stdlib.AbsoluteFunc,
+		"min":   stdlib.MinFunc,
+		"max":   stdlib.MaxFunc,
+		"floor": stdlib.FloorFunc,
+		"ceil":  stdlib.CeilFunc,
+		"pow":   stdlib.PowFunc,
 	}
 }

--- a/pkg/analysis/stdlib/stdlib_test.go
+++ b/pkg/analysis/stdlib/stdlib_test.go
@@ -155,6 +155,116 @@ var stdlibCases = []stdlibCase{
 			cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c"),
 		}),
 	},
+
+	// String functions
+	{Name: "upper", Want: cty.StringVal("HELLO")},
+	{Name: "lower", Want: cty.StringVal("hello")},
+	{Name: "join", Want: cty.StringVal("a-b-c")},
+	{
+		// split returns list(string), not tuple — explicit element type.
+		Name: "split",
+		Want: cty.ListVal([]cty.Value{
+			cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c"),
+		}),
+	},
+	{Name: "format", Want: cty.StringVal("hello world, 42")},
+	{
+		// Literal mode — substr is plain text, no `/.../` delimiters.
+		Name: "replace_literal",
+		Want: cty.StringVal("baz bar baz"),
+	},
+	{
+		// Regex mode — `/[0-9]+/` triggers the Terraform-side
+		// dispatcher in replace.go (cty's own ReplaceFunc would treat
+		// the slashes as literal).
+		Name: "replace_regex",
+		Want: cty.StringVal("abcNdef"),
+	},
+	{Name: "trim", Want: cty.StringVal("hello")},
+	{Name: "trimspace", Want: cty.StringVal("hello")},
+	{Name: "trimprefix", Want: cty.StringVal("world")},
+	{Name: "trimsuffix", Want: cty.StringVal("hello")},
+
+	// Numeric functions
+	{Name: "abs", Want: cty.NumberIntVal(5)},
+	{Name: "min", Want: cty.NumberIntVal(1)},
+	{Name: "max", Want: cty.NumberIntVal(3)},
+	{Name: "floor", Want: cty.NumberIntVal(3)},
+	{Name: "ceil", Want: cty.NumberIntVal(4)},
+	{Name: "pow", Want: cty.NumberIntVal(1024)},
+
+	// Additional batch-2 string helpers
+	{Name: "title", Want: cty.StringVal("Hello World")},
+	{Name: "substr", Want: cty.StringVal("cde")},
+	{Name: "chomp", Want: cty.StringVal("hello")},
+	{Name: "indent", Want: cty.StringVal("line1\n  line2\n  line3")},
+	{
+		Name: "formatlist",
+		Want: cty.ListVal([]cty.Value{
+			cty.StringVal("hi-a"), cty.StringVal("hi-b"), cty.StringVal("hi-c"),
+		}),
+	},
+
+	// Additional batch-2 collection helpers
+	{
+		// SortFunc returns list(string).
+		Name: "sort",
+		Want: cty.ListVal([]cty.Value{
+			cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c"),
+		}),
+	},
+	{
+		// ReverseListFunc preserves the input element type — a tuple
+		// of strings stays a tuple in reversed order.
+		Name: "reverse",
+		Want: cty.TupleVal([]cty.Value{
+			cty.StringVal("c"), cty.StringVal("b"), cty.StringVal("a"),
+		}),
+	},
+	{
+		// SliceFunc preserves the input element type; tuple slice
+		// returns a tuple of the requested span.
+		Name: "slice",
+		Want: cty.TupleVal([]cty.Value{
+			cty.StringVal("b"), cty.StringVal("c"), cty.StringVal("d"),
+		}),
+	},
+	{
+		// chunklist splits by size; trailing chunk is shorter.
+		Name: "chunklist",
+		Want: cty.ListVal([]cty.Value{
+			cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			cty.ListVal([]cty.Value{cty.StringVal("c"), cty.StringVal("d")}),
+			cty.ListVal([]cty.Value{cty.StringVal("e")}),
+		}),
+	},
+	{
+		// compact filters empty strings out of the list-of-strings.
+		Name: "compact",
+		Want: cty.ListVal([]cty.Value{
+			cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c"),
+		}),
+	},
+	{Name: "coalesce", Want: cty.StringVal("first-non-empty")},
+	{
+		Name: "coalescelist",
+		Want: cty.TupleVal([]cty.Value{cty.StringVal("first-non-empty")}),
+	},
+	{
+		// zipmap produces an object (HCL string-key shape) with
+		// per-key types from the corresponding values.
+		Name: "zipmap",
+		Want: cty.ObjectVal(map[string]cty.Value{
+			"a": cty.NumberIntVal(1), "b": cty.NumberIntVal(2),
+		}),
+	},
+	{
+		// range(1, 4) → [1, 2, 3]; result is list(number).
+		Name: "range",
+		Want: cty.ListVal([]cty.Value{
+			cty.NumberIntVal(1), cty.NumberIntVal(2), cty.NumberIntVal(3),
+		}),
+	},
 }
 
 // TestFunctionsReturnsExpectedSet pins the public surface — the
@@ -165,6 +275,12 @@ func TestFunctionsReturnsExpectedSet(t *testing.T) {
 		"toset", "tolist", "tomap", "tostring", "tonumber", "tobool",
 		"length", "concat", "merge", "keys", "values",
 		"lookup", "contains", "element", "flatten", "distinct",
+		"upper", "lower", "title", "join", "split", "format", "formatlist",
+		"replace", "trim", "trimspace", "trimprefix", "trimsuffix",
+		"chomp", "indent", "substr",
+		"sort", "reverse", "slice", "chunklist", "compact",
+		"coalesce", "coalescelist", "zipmap", "range",
+		"abs", "min", "max", "floor", "ceil", "pow",
 	}
 	got := stdlib.Functions()
 	if len(got) != len(want) {
@@ -174,6 +290,75 @@ func TestFunctionsReturnsExpectedSet(t *testing.T) {
 		if _, ok := got[name]; !ok {
 			t.Errorf("missing function %q in Functions()", name)
 		}
+	}
+}
+
+// TestEvalErrorCases exercises the error paths of the Terraform-side
+// wrappers (replace.go, coalesce.go) by evaluating malformed inputs
+// through Functions() and asserting the call surfaces diagnostics.
+// Without this the negative branches go uncovered — the happy cases
+// in TestStdlibFunctionCases only prove successful evaluation.
+func TestEvalErrorCases(t *testing.T) {
+	cases := []struct {
+		Name string
+		Src  string
+	}{
+		{
+			// replace.go: regexp.Compile rejects unterminated character
+			// classes — surfaced as evaluation diags.
+			Name: "replace_invalid_regex",
+			Src:  `locals { out = replace("abc", "/[unterminated/", "x") }`,
+		},
+		{
+			// coalesce.go: type-unification fails when args are not
+			// promotable to a common type (string vs map).
+			Name: "coalesce_mismatched_types",
+			Src:  `locals { out = coalesce("a", {b = 1}) }`,
+		},
+		{
+			// coalesce.go: all args are empty strings → falls through
+			// to the "no non-null, non-empty-string arguments" error.
+			Name: "coalesce_all_empty",
+			Src:  `locals { out = coalesce("", "", "") }`,
+		},
+		{
+			// coalesce.go: explicit nulls plus an empty string take the
+			// IsNull() branch (and then the all-empty error).
+			Name: "coalesce_only_null_and_empty",
+			Src:  `locals { out = coalesce(null, "") }`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			p := hclparse.NewParser()
+			f, diags := p.ParseHCL([]byte(tc.Src), "main.tf")
+			if diags.HasErrors() {
+				t.Fatalf("parse: %v", diags)
+			}
+			body := f.Body.(*hclsyntax.Body)
+			attr := body.Blocks[0].Body.Attributes["out"]
+			ctx := &hcl.EvalContext{Functions: stdlib.Functions()}
+			if _, evalDiags := attr.Expr.Value(ctx); !evalDiags.HasErrors() {
+				t.Errorf("expected evaluation diagnostics, got none")
+			}
+		})
+	}
+}
+
+// TestCoalesceUnknown exercises the IsKnown() short-circuit in
+// coalesce.go: an unknown-typed argument causes the function to
+// return UnknownVal rather than skipping or erroring. Driven through
+// the Function directly because HCL literals are always known.
+func TestCoalesceUnknown(t *testing.T) {
+	got, err := stdlib.Functions()["coalesce"].Call([]cty.Value{
+		cty.UnknownVal(cty.String),
+		cty.StringVal("fallback"),
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if got.IsKnown() {
+		t.Errorf("coalesce(unknown, ...) should return Unknown, got %#v", got)
 	}
 }
 

--- a/pkg/analysis/stdlib/testdata/abs/main.tf
+++ b/pkg/analysis/stdlib/testdata/abs/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = abs(-5)
+}

--- a/pkg/analysis/stdlib/testdata/ceil/main.tf
+++ b/pkg/analysis/stdlib/testdata/ceil/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = ceil(3.2)
+}

--- a/pkg/analysis/stdlib/testdata/chomp/main.tf
+++ b/pkg/analysis/stdlib/testdata/chomp/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = chomp("hello\n\n")
+}

--- a/pkg/analysis/stdlib/testdata/chunklist/main.tf
+++ b/pkg/analysis/stdlib/testdata/chunklist/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = chunklist(["a", "b", "c", "d", "e"], 2)
+}

--- a/pkg/analysis/stdlib/testdata/coalesce/main.tf
+++ b/pkg/analysis/stdlib/testdata/coalesce/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = coalesce("", "", "first-non-empty", "later")
+}

--- a/pkg/analysis/stdlib/testdata/coalescelist/main.tf
+++ b/pkg/analysis/stdlib/testdata/coalescelist/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = coalescelist([], ["first-non-empty"], ["later"])
+}

--- a/pkg/analysis/stdlib/testdata/compact/main.tf
+++ b/pkg/analysis/stdlib/testdata/compact/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = compact(["a", "", "b", "", "c"])
+}

--- a/pkg/analysis/stdlib/testdata/floor/main.tf
+++ b/pkg/analysis/stdlib/testdata/floor/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = floor(3.7)
+}

--- a/pkg/analysis/stdlib/testdata/format/main.tf
+++ b/pkg/analysis/stdlib/testdata/format/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = format("hello %s, %d", "world", 42)
+}

--- a/pkg/analysis/stdlib/testdata/formatlist/main.tf
+++ b/pkg/analysis/stdlib/testdata/formatlist/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = formatlist("hi-%s", ["a", "b", "c"])
+}

--- a/pkg/analysis/stdlib/testdata/indent/main.tf
+++ b/pkg/analysis/stdlib/testdata/indent/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = indent(2, "line1\nline2\nline3")
+}

--- a/pkg/analysis/stdlib/testdata/join/main.tf
+++ b/pkg/analysis/stdlib/testdata/join/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = join("-", ["a", "b", "c"])
+}

--- a/pkg/analysis/stdlib/testdata/lower/main.tf
+++ b/pkg/analysis/stdlib/testdata/lower/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = lower("HELLO")
+}

--- a/pkg/analysis/stdlib/testdata/max/main.tf
+++ b/pkg/analysis/stdlib/testdata/max/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = max(3, 1, 2)
+}

--- a/pkg/analysis/stdlib/testdata/min/main.tf
+++ b/pkg/analysis/stdlib/testdata/min/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = min(3, 1, 2)
+}

--- a/pkg/analysis/stdlib/testdata/pow/main.tf
+++ b/pkg/analysis/stdlib/testdata/pow/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = pow(2, 10)
+}

--- a/pkg/analysis/stdlib/testdata/range/main.tf
+++ b/pkg/analysis/stdlib/testdata/range/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = range(1, 4)
+}

--- a/pkg/analysis/stdlib/testdata/replace_literal/main.tf
+++ b/pkg/analysis/stdlib/testdata/replace_literal/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = replace("foo bar foo", "foo", "baz")
+}

--- a/pkg/analysis/stdlib/testdata/replace_regex/main.tf
+++ b/pkg/analysis/stdlib/testdata/replace_regex/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = replace("abc123def", "/[0-9]+/", "N")
+}

--- a/pkg/analysis/stdlib/testdata/reverse/main.tf
+++ b/pkg/analysis/stdlib/testdata/reverse/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = reverse(["a", "b", "c"])
+}

--- a/pkg/analysis/stdlib/testdata/slice/main.tf
+++ b/pkg/analysis/stdlib/testdata/slice/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = slice(["a", "b", "c", "d", "e"], 1, 4)
+}

--- a/pkg/analysis/stdlib/testdata/sort/main.tf
+++ b/pkg/analysis/stdlib/testdata/sort/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = sort(["c", "a", "b"])
+}

--- a/pkg/analysis/stdlib/testdata/split/main.tf
+++ b/pkg/analysis/stdlib/testdata/split/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = split(",", "a,b,c")
+}

--- a/pkg/analysis/stdlib/testdata/substr/main.tf
+++ b/pkg/analysis/stdlib/testdata/substr/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = substr("abcdefgh", 2, 3)
+}

--- a/pkg/analysis/stdlib/testdata/title/main.tf
+++ b/pkg/analysis/stdlib/testdata/title/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = title("hello world")
+}

--- a/pkg/analysis/stdlib/testdata/trim/main.tf
+++ b/pkg/analysis/stdlib/testdata/trim/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = trim("!?hello?!", "!?")
+}

--- a/pkg/analysis/stdlib/testdata/trimprefix/main.tf
+++ b/pkg/analysis/stdlib/testdata/trimprefix/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = trimprefix("hello-world", "hello-")
+}

--- a/pkg/analysis/stdlib/testdata/trimspace/main.tf
+++ b/pkg/analysis/stdlib/testdata/trimspace/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = trimspace("  hello  ")
+}

--- a/pkg/analysis/stdlib/testdata/trimsuffix/main.tf
+++ b/pkg/analysis/stdlib/testdata/trimsuffix/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = trimsuffix("hello-world", "-world")
+}

--- a/pkg/analysis/stdlib/testdata/upper/main.tf
+++ b/pkg/analysis/stdlib/testdata/upper/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = upper("hello")
+}

--- a/pkg/analysis/stdlib/testdata/zipmap/main.tf
+++ b/pkg/analysis/stdlib/testdata/zipmap/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = zipmap(["a", "b"], [1, 2])
+}

--- a/pkg/diff/testdata/tracked_eval_format_collapses/new.tf
+++ b/pkg/diff/testdata/tracked_eval_format_collapses/new.tf
@@ -1,0 +1,5 @@
+locals {
+  # Refactor: same string assembled via format() instead of inlined.
+  # Effective value unchanged → Informational, not Breaking.
+  image = format("ec2-%s-v%d", "small", 3) # tflens:track: AMI image identifier
+}

--- a/pkg/diff/testdata/tracked_eval_format_collapses/old.tf
+++ b/pkg/diff/testdata/tracked_eval_format_collapses/old.tf
@@ -1,0 +1,3 @@
+locals {
+  image = "ec2-small-v3" # tflens:track: AMI image identifier
+}

--- a/pkg/diff/testdata/tracked_eval_lower_collapses/new.tf
+++ b/pkg/diff/testdata/tracked_eval_lower_collapses/new.tf
@@ -1,0 +1,5 @@
+locals {
+  # Author lowercased a constant via lower() rather than typing it
+  # in the canonical form. Effective string identical → Informational.
+  region = lower("US-EAST-1") # tflens:track: target deployment region
+}

--- a/pkg/diff/testdata/tracked_eval_lower_collapses/old.tf
+++ b/pkg/diff/testdata/tracked_eval_lower_collapses/old.tf
@@ -1,0 +1,3 @@
+locals {
+  region = "us-east-1" # tflens:track: target deployment region
+}

--- a/pkg/diff/tracked_test.go
+++ b/pkg/diff/tracked_test.go
@@ -256,6 +256,24 @@ var trackedCases = []trackedCase{
 		DetailContains: []string{"value"},
 	},
 	{
+		// Stdlib batch 2 (lower): refactor lowercases a constant via
+		// lower() instead of typing the canonical form. Effective
+		// string identical → Informational, not Breaking.
+		Name:           "tracked_eval_lower_collapses",
+		Subject:        "local.region.value",
+		WantKind:       diff.Informational,
+		DetailContains: []string{"no effective value change"},
+	},
+	{
+		// Stdlib batch 2 (format): same string assembled via format()
+		// rather than inlined. Effective value unchanged →
+		// Informational. Verifies %s + %d formatters round-trip.
+		Name:           "tracked_eval_format_collapses",
+		Subject:        "local.image.value",
+		WantKind:       diff.Informational,
+		DetailContains: []string{"no effective value change"},
+	},
+	{
 		Name:           "tracked_literal_value_changed",
 		Subject:        "resource.aws_eks_cluster.this.cluster_version",
 		WantKind:       diff.Breaking,

--- a/pkg/statediff/effective_value_test.go
+++ b/pkg/statediff/effective_value_test.go
@@ -68,6 +68,18 @@ var effectiveValueCases = []effectiveValueCase{
 		Name:        "length_change_still_flags",
 		WantFlagged: true,
 	},
+	{
+		// Stdlib batch 2 (lower): canonical form vs lower("US-EAST-1")
+		// — same effective string. Local reaches for_each but no
+		// SensitiveChange should fire.
+		Name: "lower_collapses",
+	},
+	{
+		// Stdlib batch 2 (format): same string assembled via
+		// format("ec2-%s-v%d", "small", 3) vs literal. Effective value
+		// identical → suppressed.
+		Name: "format_collapses",
+	},
 }
 
 func loadEffectiveValueFixture(t *testing.T, caseName, side string) *loader.Project {

--- a/pkg/statediff/testdata/effective_value_collapse/format_collapses/feature/main.tf
+++ b/pkg/statediff/testdata/effective_value_collapse/format_collapses/feature/main.tf
@@ -1,0 +1,9 @@
+locals {
+  # Same string assembled via format() — text differs but the
+  # evaluated value matches. SensitiveChange should not fire.
+  image = format("ec2-%s-v%d", "small", 3)
+}
+
+resource "aws_instance" "web" {
+  for_each = toset([local.image])
+}

--- a/pkg/statediff/testdata/effective_value_collapse/format_collapses/main/main.tf
+++ b/pkg/statediff/testdata/effective_value_collapse/format_collapses/main/main.tf
@@ -1,0 +1,7 @@
+locals {
+  image = "ec2-small-v3"
+}
+
+resource "aws_instance" "web" {
+  for_each = toset([local.image])
+}

--- a/pkg/statediff/testdata/effective_value_collapse/lower_collapses/feature/main.tf
+++ b/pkg/statediff/testdata/effective_value_collapse/lower_collapses/feature/main.tf
@@ -1,0 +1,10 @@
+locals {
+  # Refactor pushed the canonical form through lower(); effective
+  # string identical → no SensitiveChange even though the local
+  # reaches for_each.
+  region = lower("US-EAST-1")
+}
+
+resource "aws_instance" "web" {
+  for_each = toset([local.region])
+}

--- a/pkg/statediff/testdata/effective_value_collapse/lower_collapses/main/main.tf
+++ b/pkg/statediff/testdata/effective_value_collapse/lower_collapses/main/main.tf
@@ -1,0 +1,7 @@
+locals {
+  region = "us-east-1"
+}
+
+resource "aws_instance" "web" {
+  for_each = toset([local.region])
+}


### PR DESCRIPTION
## Summary

- 30 more Terraform built-ins wired into `Module.EvalContext` on top of batch 1's 16 (curated set now 46): strings (`upper`, `lower`, `title`, `join`, `split`, `format`, `formatlist`, `replace`, `trim*`, `chomp`, `indent`, `substr`), numerics (`abs`, `min`, `max`, `floor`, `ceil`, `pow`), and extended collections (`sort`, `reverse`, `slice`, `chunklist`, `compact`, `coalesce`, `coalescelist`, `zipmap`, `range`).
- Same effective-value-collapse machinery introduced in batch 1 now suppresses false positives across this surface — e.g. `"us-east-1"` ↔ `lower("US-EAST-1")`, `["a","b","c"]` ↔ `sort(["c","b","a"])`, `"ec2-small-v3"` ↔ `format("ec2-%s-v%d", "small", 3)`.
- Two Terraform-faithful wrappers because cty's defaults diverge: `replace` (regex dispatch on `/pattern/`) and `coalesce` (skip empty strings as well as nulls).

## Test plan

- [x] `make check` (vet + test + gofmt) — all packages pass
- [x] 35 happy-path stdlib fixtures + 4 negative-path coalesce/replace error cases
- [x] 2 end-to-end statediff cases (`lower_collapses`, `format_collapses`) confirming SensitiveChange suppression
- [x] 2 end-to-end tracked-attribute cases (`tracked_eval_lower_collapses`, `tracked_eval_format_collapses`) confirming Informational (not Breaking) classification
- [x] `pkg/analysis/stdlib` package coverage at 100%