### PR TITLE
feat: stdlib regex mini-batch — wire regex + regexall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to tflens are documented here. The format is loosely based o
 
 ## [Unreleased]
 
+### Changed
+
+- **Terraform stdlib functions: regex mini-batch (`regex`, `regexall`).** Wired into `Module.EvalContext` via `pkg/analysis/stdlib/stdlib.go`, bringing the curated set to 48. Both come straight from `cty/function/stdlib` — cty uses Go's `regexp` (RE2), the same engine Terraform uses, so behaviour matches without a wrapper. Capture-group return-type shape is dispatched on the pattern at evaluation time: no groups → `string`, unnamed groups → tuple of captures, named groups → object keyed by group name. The same effective-value-collapse machinery now suppresses regex-based refactors — e.g. `local.major = "1"` ↔ `local.major = regex("^[0-9]+", "1.34.2")` no longer flags as a change. cty's `RegexReplaceFunc` is deliberately NOT exposed: Terraform doesn't have a `regexreplace` function — regex replacement is the `/pattern/` form of `replace`, which the existing `replace` wrapper already dispatches. New per-function fixtures pin all three capture-group return shapes (`regex_no_groups`, `regex_unnamed_groups`, `regex_named_groups`) plus `regexall`, plus negative-path coverage for unmatched-pattern and invalid-pattern errors. End-to-end tracked-attribute suppression case under `pkg/diff/testdata/tracked_eval_regex_collapses/`.
+
 ## [0.4.1] — 2026-04-25
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -539,9 +539,10 @@ The curated function set is intentionally a subset of Terraform's built-ins, not
 | Type conversion | `toset`, `tolist`, `tomap`, `tostring`, `tonumber`, `tobool` |
 | Collections | `length`, `concat`, `merge`, `keys`, `values`, `lookup`, `contains`, `element`, `flatten`, `distinct`, `sort`, `reverse`, `slice`, `chunklist`, `compact`, `coalesce`, `coalescelist`, `zipmap`, `range` |
 | String | `upper`, `lower`, `title`, `join`, `split`, `format`, `formatlist`, `replace` (literal + `/regex/` dispatch), `trim`, `trimspace`, `trimprefix`, `trimsuffix`, `chomp`, `indent`, `substr` |
+| Regex | `regex` (string / tuple / object return depending on capture groups), `regexall` |
 | Numeric | `abs`, `min`, `max`, `floor`, `ceil`, `pow` |
 
-**Deliberately excluded** (and unlikely to be added): filesystem (`file`, `fileset`, `templatefile`) — needs filesystem context that isn't valid for static analysis; non-deterministic (`timestamp`, `uuid`, `bcrypt`) — must always return unknown; complex semantics (`can`, `try`) — needs full Terraform evaluator catch-and-retry. **Not yet wired but plausible** for future batches: `regex`/`regexall`/`regexreplace`, `jsondecode`/`jsonencode`, `formatdate`, `parseint`, `signum`, `log`.
+**Deliberately excluded** (and unlikely to be added): filesystem (`file`, `fileset`, `templatefile`) — needs filesystem context that isn't valid for static analysis; non-deterministic (`timestamp`, `uuid`, `bcrypt`) — must always return unknown; complex semantics (`can`, `try`) — needs full Terraform evaluator catch-and-retry; `regexreplace` — Terraform exposes regex replacement only through the `/pattern/` form of `replace`, which the curated `replace` already dispatches. **Not yet wired but plausible** for future batches: `jsondecode`/`jsonencode`, `formatdate`, `parseint`, `signum`, `log`.
 
 ## Editor integration
 

--- a/pkg/analysis/stdlib/stdlib.go
+++ b/pkg/analysis/stdlib/stdlib.go
@@ -77,6 +77,19 @@ func Functions() map[string]function.Function {
 		"indent":     stdlib.IndentFunc,
 		"substr":     stdlib.SubstrFunc,
 
+		// Regex family. cty's implementations use Go's regexp (RE2),
+		// the same engine Terraform uses, so behaviour matches directly
+		// without a wrapper. Capture-group return-type shape (string /
+		// tuple / object) is dispatched on the pattern at evaluation
+		// time — see the corresponding testdata fixtures. Note: cty has
+		// a `RegexReplaceFunc` but Terraform doesn't expose it as a
+		// distinct function — regex replacement happens via the
+		// `/pattern/` form of `replace` (handled by replace.go's
+		// dispatcher). Wiring `regexreplace` here would diverge from
+		// Terraform.
+		"regex":    stdlib.RegexFunc,
+		"regexall": stdlib.RegexAllFunc,
+
 		// Additional collection helpers — same value-collapse story as
 		// the batch-1 collection functions; these are the next tier of
 		// commonly-used Terraform-stdlib pure functions.

--- a/pkg/analysis/stdlib/stdlib_test.go
+++ b/pkg/analysis/stdlib/stdlib_test.go
@@ -265,6 +265,42 @@ var stdlibCases = []stdlibCase{
 			cty.NumberIntVal(1), cty.NumberIntVal(2), cty.NumberIntVal(3),
 		}),
 	},
+
+	// Regex family — return-type shape dispatches on the pattern's
+	// capture-group structure (no groups → string, unnamed → tuple,
+	// named → object). Pin all three shapes so future cty upgrades
+	// can't silently change the contract.
+	{
+		// No capture groups → returns the matched substring as a string.
+		Name: "regex_no_groups",
+		Want: cty.StringVal("abc"),
+	},
+	{
+		// Unnamed groups → returns a tuple of the captured substrings,
+		// in declaration order. The match itself ($0) is NOT included
+		// when groups are present.
+		Name: "regex_unnamed_groups",
+		Want: cty.TupleVal([]cty.Value{
+			cty.StringVal("abc"), cty.StringVal("123"),
+		}),
+	},
+	{
+		// Named groups → returns an object keyed by group name. Same
+		// "no $0" rule as unnamed groups.
+		Name: "regex_named_groups",
+		Want: cty.ObjectVal(map[string]cty.Value{
+			"word": cty.StringVal("abc"),
+			"num":  cty.StringVal("123"),
+		}),
+	},
+	{
+		// regexall returns every non-overlapping match as a list (not
+		// tuple) — element type is uniform.
+		Name: "regexall",
+		Want: cty.ListVal([]cty.Value{
+			cty.StringVal("abc"), cty.StringVal("def"), cty.StringVal("ghi"),
+		}),
+	},
 }
 
 // TestFunctionsReturnsExpectedSet pins the public surface — the
@@ -280,6 +316,7 @@ func TestFunctionsReturnsExpectedSet(t *testing.T) {
 		"chomp", "indent", "substr",
 		"sort", "reverse", "slice", "chunklist", "compact",
 		"coalesce", "coalescelist", "zipmap", "range",
+		"regex", "regexall",
 		"abs", "min", "max", "floor", "ceil", "pow",
 	}
 	got := stdlib.Functions()
@@ -326,6 +363,19 @@ func TestEvalErrorCases(t *testing.T) {
 			// IsNull() branch (and then the all-empty error).
 			Name: "coalesce_only_null_and_empty",
 			Src:  `locals { out = coalesce(null, "") }`,
+		},
+		{
+			// regex with no match: cty's RegexFunc errors out (matches
+			// Terraform). Use regexall when "no match → empty" is the
+			// desired behaviour.
+			Name: "regex_no_match_errors",
+			Src:  `locals { out = regex("[0-9]+", "no-digits-here") }`,
+		},
+		{
+			// Invalid regex pattern — surfaces as an arg error from
+			// regexp.Compile.
+			Name: "regex_invalid_pattern",
+			Src:  `locals { out = regex("[unterminated", "abc") }`,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/analysis/stdlib/testdata/regex_named_groups/main.tf
+++ b/pkg/analysis/stdlib/testdata/regex_named_groups/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = regex("(?P<word>[a-z]+)-(?P<num>[0-9]+)", "abc-123-def")
+}

--- a/pkg/analysis/stdlib/testdata/regex_no_groups/main.tf
+++ b/pkg/analysis/stdlib/testdata/regex_no_groups/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = regex("[a-z]+", "abc-123-def")
+}

--- a/pkg/analysis/stdlib/testdata/regex_unnamed_groups/main.tf
+++ b/pkg/analysis/stdlib/testdata/regex_unnamed_groups/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = regex("([a-z]+)-([0-9]+)", "abc-123-def")
+}

--- a/pkg/analysis/stdlib/testdata/regexall/main.tf
+++ b/pkg/analysis/stdlib/testdata/regexall/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = regexall("[a-z]+", "abc-123-def-456-ghi")
+}

--- a/pkg/diff/testdata/tracked_eval_regex_collapses/new.tf
+++ b/pkg/diff/testdata/tracked_eval_regex_collapses/new.tf
@@ -1,0 +1,6 @@
+locals {
+  # Refactor: same string extracted from a tag via regex() rather
+  # than typed as a literal. Effective value identical →
+  # Informational, not Breaking.
+  major = regex("^[0-9]+", "1.34.2") # tflens:track: major version channel
+}

--- a/pkg/diff/testdata/tracked_eval_regex_collapses/old.tf
+++ b/pkg/diff/testdata/tracked_eval_regex_collapses/old.tf
@@ -1,0 +1,3 @@
+locals {
+  major = "1" # tflens:track: major version channel
+}

--- a/pkg/diff/tracked_test.go
+++ b/pkg/diff/tracked_test.go
@@ -274,6 +274,16 @@ var trackedCases = []trackedCase{
 		DetailContains: []string{"no effective value change"},
 	},
 	{
+		// Stdlib batch 2.5 (regex): refactor pulls a substring via
+		// regex() rather than inlining the literal. Effective value
+		// identical → Informational. Pins regex(pattern, string)
+		// no-capture-group return shape (string, not tuple/object).
+		Name:           "tracked_eval_regex_collapses",
+		Subject:        "local.major.value",
+		WantKind:       diff.Informational,
+		DetailContains: []string{"no effective value change"},
+	},
+	{
 		Name:           "tracked_literal_value_changed",
 		Subject:        "resource.aws_eks_cluster.this.cluster_version",
 		WantKind:       diff.Breaking,


### PR DESCRIPTION
## Summary

- Wires `regex` and `regexall` into `Module.EvalContext` via `pkg/analysis/stdlib/stdlib.go`. Curated set goes from 46 → 48.
- Direct `cty/function/stdlib` wraps — no Terraform-side wrapper needed (cty uses Go's `regexp` / RE2, same as Terraform).
- Capture-group return-type shape is dispatched on the pattern at evaluation time: no groups → `string`, unnamed groups → tuple, named groups → object. All three shapes pinned by per-function fixtures.
- `regexreplace` deliberately NOT exposed: Terraform doesn't have it as a distinct function — regex replacement is the `/pattern/` form of `replace`, which the existing `replace` wrapper already dispatches. Wiring it would diverge from Terraform.

## Test plan

- [x] `make check` (vet + test + gofmt) — all packages pass
- [x] `regex_no_groups`, `regex_unnamed_groups`, `regex_named_groups`, `regexall` fixtures pin all four return shapes
- [x] `regex_no_match_errors` + `regex_invalid_pattern` cover the eval-error paths via `TestEvalErrorCases`
- [x] End-to-end `tracked_eval_regex_collapses` confirms suppression of regex-based refactors
- [x] `pkg/analysis/stdlib` package coverage at 100%
- [x] README "Static evaluation surface" table updated; `regexreplace` moved to "Deliberately excluded" with rationale