### PR TITLE
feat: stdlib completion batch — encoders, set ops, index/parseint (+base64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to tflens are documented here. The format is loosely based o
 
 ## [Unreleased]
 
+### Changed
+
+- **Terraform stdlib functions: completion batch (encoders, set algebra, list/numeric pickups).** Wires 12 more Terraform built-ins into `Module.EvalContext`, bringing the curated set to 60. Encoders/decoders (5): `jsonencode`, `jsondecode`, `csvdecode`, `base64encode`, `base64decode` — `base64*` need Terraform-side wrappers in `pkg/analysis/stdlib/base64.go` because cty doesn't expose them; the JSON and CSV variants come straight from cty. Set algebra (5): `setunion`, `setintersection`, `setsubtract`, `setsymmetricdifference`, `setproduct` — direct cty wraps, common in `for_each` composition. Pickups (2): `index` (find position of value in list — needs a Terraform-side wrapper in `pkg/analysis/stdlib/index.go` because cty's `IndexFunc` is a different function entirely, returning the element AT a given key rather than searching for a value's position) and `parseint` (string → number in arbitrary base, direct cty wrap). The same effective-value-collapse machinery now suppresses encoder-based refactors — the most common real-world case being IAM policies switching between a raw JSON string and an HCL object + `jsonencode()`. New per-function table tests under `pkg/analysis/stdlib/testdata/<func>/main.tf` (12 fixtures), 4 negative-path cases (`base64decode_invalid`, `base64decode_non_utf8`, `jsondecode_invalid`, `index_*`), 1 partially-unknown coverage case for the `index` short-circuit, and an end-to-end tracked-attribute case under `pkg/diff/testdata/tracked_eval_jsonencode_collapses/`. `pkg/analysis/stdlib` package coverage at 100%. README's "Static evaluation surface" table updated; the previously-listed "plausible for future batches" items are reorganised — high-value ones (json, base64, set ops, index, parseint) are now wired; low-value ones (`formatdate`, `timeadd`, `signum`, `log`) move to "Deliberately excluded" with rationale.
+
 ## [0.5.0] — 2026-04-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -537,12 +537,14 @@ The curated function set is intentionally a subset of Terraform's built-ins, not
 | Group | Functions |
 | --- | --- |
 | Type conversion | `toset`, `tolist`, `tomap`, `tostring`, `tonumber`, `tobool` |
-| Collections | `length`, `concat`, `merge`, `keys`, `values`, `lookup`, `contains`, `element`, `flatten`, `distinct`, `sort`, `reverse`, `slice`, `chunklist`, `compact`, `coalesce`, `coalescelist`, `zipmap`, `range` |
+| Collections | `length`, `concat`, `merge`, `keys`, `values`, `lookup`, `contains`, `element`, `flatten`, `distinct`, `sort`, `reverse`, `slice`, `chunklist`, `compact`, `coalesce`, `coalescelist`, `zipmap`, `range`, `index` |
+| Sets | `setunion`, `setintersection`, `setsubtract`, `setsymmetricdifference`, `setproduct` |
 | String | `upper`, `lower`, `title`, `join`, `split`, `format`, `formatlist`, `replace` (literal + `/regex/` dispatch), `trim`, `trimspace`, `trimprefix`, `trimsuffix`, `chomp`, `indent`, `substr` |
 | Regex | `regex` (string / tuple / object return depending on capture groups), `regexall` |
-| Numeric | `abs`, `min`, `max`, `floor`, `ceil`, `pow` |
+| Encoders / decoders | `jsonencode`, `jsondecode`, `csvdecode`, `base64encode`, `base64decode` |
+| Numeric | `abs`, `min`, `max`, `floor`, `ceil`, `pow`, `parseint` |
 
-**Deliberately excluded** (and unlikely to be added): filesystem (`file`, `fileset`, `templatefile`) — needs filesystem context that isn't valid for static analysis; non-deterministic (`timestamp`, `uuid`, `bcrypt`) — must always return unknown; complex semantics (`can`, `try`) — needs full Terraform evaluator catch-and-retry; `regexreplace` — Terraform exposes regex replacement only through the `/pattern/` form of `replace`, which the curated `replace` already dispatches. **Not yet wired but plausible** for future batches: `jsondecode`/`jsonencode`, `formatdate`, `parseint`, `signum`, `log`.
+**Deliberately excluded** (and unlikely to be added): filesystem (`file`, `fileset`, `templatefile`) — needs filesystem context that isn't valid for static analysis; non-deterministic (`timestamp`, `uuid`, `bcrypt`) and time-based hashing (`base64sha256`, `base64sha512`, `filebase64sha256`, `md5`, `sha1`, etc.) — must always return unknown or need crypto state that isn't pure-functional; complex semantics (`can`, `try`) — needs full Terraform evaluator catch-and-retry; `regexreplace` — Terraform exposes regex replacement only through the `/pattern/` form of `replace`, which the curated `replace` already dispatches; date/time helpers (`formatdate`, `timeadd`) — input is usually `timestamp()` (excluded) and standalone uses are rare; rarely-used numerics (`signum`, `log`) — almost never seen in real modules.
 
 ## Editor integration
 

--- a/pkg/analysis/stdlib/base64.go
+++ b/pkg/analysis/stdlib/base64.go
@@ -1,0 +1,45 @@
+package stdlib
+
+import (
+	"encoding/base64"
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// terraformBase64EncodeFunc mirrors Terraform's `base64encode(string)`:
+// returns the std-encoding base64 of the input string. Terraform exposes
+// these in lang/funcs rather than cty, so the wrapper is needed.
+var terraformBase64EncodeFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{Name: "str", Type: cty.String},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		return cty.StringVal(base64.StdEncoding.EncodeToString([]byte(args[0].AsString()))), nil
+	},
+})
+
+// terraformBase64DecodeFunc mirrors Terraform's `base64decode(string)`:
+// decodes std-encoding base64 to a UTF-8 string. Errors on invalid
+// base64 (matches Terraform). Errors on non-UTF-8 output too — that
+// covers binary payloads that aren't legal as a Terraform string,
+// matching Terraform's "the result must be valid UTF-8" rule.
+var terraformBase64DecodeFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{Name: "str", Type: cty.String},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		raw, err := base64.StdEncoding.DecodeString(args[0].AsString())
+		if err != nil {
+			return cty.UnknownVal(cty.String), fmt.Errorf("failed to decode base64: %w", err)
+		}
+		if !utf8.Valid(raw) {
+			return cty.UnknownVal(cty.String), fmt.Errorf("the result of decoding the provided string is not valid UTF-8")
+		}
+		return cty.StringVal(string(raw)), nil
+	},
+})

--- a/pkg/analysis/stdlib/index.go
+++ b/pkg/analysis/stdlib/index.go
@@ -1,0 +1,48 @@
+package stdlib
+
+import (
+	"errors"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+// terraformIndexFunc mirrors Terraform's `index(list, value)`, which
+// returns the position of the first occurrence of `value` in `list`.
+// cty's stdlib.IndexFunc is a different function (it returns the
+// element AT a given key), so wiring cty's directly would silently
+// give the wrong answer for `index([…], "x")` — wrong both in shape
+// (returns the value, not the position) and in error semantics.
+var terraformIndexFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{Name: "list", Type: cty.DynamicPseudoType},
+		{Name: "value", Type: cty.DynamicPseudoType, AllowDynamicType: true},
+	},
+	Type: function.StaticReturnType(cty.Number),
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		// The function machinery (no AllowUnknown on the list param)
+		// already short-circuits on unknown args before we get here,
+		// so no IsKnown() guard is needed in the Impl. Likewise, type-
+		// mismatched Equal calls (e.g. comparing a string against a
+		// number element) return cty.False rather than an error, so no
+		// err-skip path is reachable through normal evaluation.
+		if !(args[0].Type().IsListType() || args[0].Type().IsTupleType()) {
+			return cty.NilVal, errors.New("argument must be a list or tuple")
+		}
+		if args[0].LengthInt() == 0 {
+			return cty.NilVal, errors.New("cannot search an empty list")
+		}
+		for it := args[0].ElementIterator(); it.Next(); {
+			i, v := it.Element()
+			eq, _ := stdlib.Equal(v, args[1])
+			if !eq.IsKnown() {
+				return cty.UnknownVal(cty.Number), nil
+			}
+			if eq.True() {
+				return i, nil
+			}
+		}
+		return cty.NilVal, errors.New("item not found")
+	},
+})

--- a/pkg/analysis/stdlib/stdlib.go
+++ b/pkg/analysis/stdlib/stdlib.go
@@ -10,12 +10,17 @@
 // Most implementations come from cty/function/stdlib, which is the
 // same library Terraform itself uses for these specific functions.
 // Wrapping them here means our evaluation behaviour matches
-// Terraform's exactly for the functions we cover. The two exceptions
-// — `replace` and `coalesce` — diverge from cty's defaults: Terraform
-// dispatches `replace` on whether the search arg is `/regex/`-
-// delimited, and Terraform's `coalesce` skips empty strings, not just
-// nulls. See replace.go and coalesce.go for the wrappers that restore
-// Terraform's contract.
+// Terraform's exactly for the functions we cover. A handful of
+// functions need Terraform-side wrappers because they diverge from
+// cty's defaults or aren't in cty at all:
+//
+//   - replace.go  — Terraform dispatches `/regex/` to a regex impl;
+//     cty's ReplaceFunc is literal-only.
+//   - coalesce.go — Terraform skips empty strings, not just nulls.
+//   - index.go    — cty's IndexFunc returns the element AT a given
+//     key; Terraform's `index` returns the position of a value.
+//   - base64.go   — cty doesn't expose base64 encode/decode at all
+//     (Terraform implements them in lang/funcs).
 //
 // Functions that would need filesystem access (file, fileset,
 // templatefile), non-deterministic state (timestamp, uuid, bcrypt),
@@ -89,6 +94,33 @@ func Functions() map[string]function.Function {
 		// Terraform.
 		"regex":    stdlib.RegexFunc,
 		"regexall": stdlib.RegexAllFunc,
+
+		// Encoders / decoders. JSON round-trip in particular powers a
+		// lot of real-world value-collapse — IAM policies and configs
+		// often switch between an object literal + jsonencode() and a
+		// raw JSON string. base64 covers cloud-init userdata and
+		// similar binary payloads. The hashing/compression base64*
+		// variants (base64gzip, base64sha256, base64sha512) need
+		// crypto state that isn't pure-functional and are out.
+		"jsondecode":   stdlib.JSONDecodeFunc,
+		"jsonencode":   stdlib.JSONEncodeFunc,
+		"csvdecode":    stdlib.CSVDecodeFunc,
+		"base64encode": terraformBase64EncodeFunc,
+		"base64decode": terraformBase64DecodeFunc,
+
+		// Set-algebra helpers. Common in for_each composition where
+		// the iteration set is built from multiple inputs.
+		"setunion":               stdlib.SetUnionFunc,
+		"setintersection":        stdlib.SetIntersectionFunc,
+		"setsubtract":            stdlib.SetSubtractFunc,
+		"setsymmetricdifference": stdlib.SetSymmetricDifferenceFunc,
+		"setproduct":             stdlib.SetProductFunc,
+
+		// List + numeric pickups. `index` needs a Terraform-side
+		// wrapper because cty's IndexFunc is a different function
+		// (returns the element AT a given key); see index.go.
+		"index":    terraformIndexFunc,
+		"parseint": stdlib.ParseIntFunc,
 
 		// Additional collection helpers — same value-collapse story as
 		// the batch-1 collection functions; these are the next tier of

--- a/pkg/analysis/stdlib/stdlib_test.go
+++ b/pkg/analysis/stdlib/stdlib_test.go
@@ -301,6 +301,81 @@ var stdlibCases = []stdlibCase{
 			cty.StringVal("abc"), cty.StringVal("def"), cty.StringVal("ghi"),
 		}),
 	},
+
+	// Encoders / decoders. JSON object keys are emitted in sorted
+	// order (Go encoding/json default) which is also what cty does.
+	{
+		Name: "jsonencode",
+		Want: cty.StringVal(`{"a":1,"b":"two"}`),
+	},
+	{
+		// jsondecode of a JSON object → cty.Object with one attribute
+		// per key. Numeric values become cty.Number; strings cty.String.
+		Name: "jsondecode",
+		Want: cty.ObjectVal(map[string]cty.Value{
+			"a": cty.NumberIntVal(1),
+			"b": cty.StringVal("two"),
+		}),
+	},
+	{
+		// csvdecode treats the first row as headers; subsequent rows
+		// become objects keyed by header. cty unifies the row objects
+		// (same attribute set + types) into a list, not a tuple.
+		Name: "csvdecode",
+		Want: cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("web"), "size": cty.StringVal("small"),
+			}),
+			cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("db"), "size": cty.StringVal("large"),
+			}),
+		}),
+	},
+	{Name: "base64encode", Want: cty.StringVal("aGVsbG8=")},
+	{Name: "base64decode", Want: cty.StringVal("hello")},
+
+	// Set algebra. cty preserves set semantics — order-insensitive,
+	// duplicate-folding. SetVal with the same element set RawEquals
+	// regardless of input ordering.
+	{
+		Name: "setunion",
+		Want: cty.SetVal([]cty.Value{
+			cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c"),
+		}),
+	},
+	{
+		Name: "setintersection",
+		Want: cty.SetVal([]cty.Value{
+			cty.StringVal("b"), cty.StringVal("c"),
+		}),
+	},
+	{
+		Name: "setsubtract",
+		Want: cty.SetVal([]cty.Value{
+			cty.StringVal("a"), cty.StringVal("c"),
+		}),
+	},
+	{
+		Name: "setsymmetricdifference",
+		Want: cty.SetVal([]cty.Value{
+			cty.StringVal("a"), cty.StringVal("c"),
+		}),
+	},
+	{
+		// setproduct of two list/tuple inputs preserves ordering and
+		// returns a list of tuples (cartesian pairs).
+		Name: "setproduct",
+		Want: cty.ListVal([]cty.Value{
+			cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("x")}),
+			cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("y")}),
+			cty.TupleVal([]cty.Value{cty.StringVal("b"), cty.StringVal("x")}),
+			cty.TupleVal([]cty.Value{cty.StringVal("b"), cty.StringVal("y")}),
+		}),
+	},
+
+	// List + numeric pickups
+	{Name: "index", Want: cty.NumberIntVal(1)},
+	{Name: "parseint", Want: cty.NumberIntVal(255)},
 }
 
 // TestFunctionsReturnsExpectedSet pins the public surface — the
@@ -317,6 +392,11 @@ func TestFunctionsReturnsExpectedSet(t *testing.T) {
 		"sort", "reverse", "slice", "chunklist", "compact",
 		"coalesce", "coalescelist", "zipmap", "range",
 		"regex", "regexall",
+		"jsonencode", "jsondecode", "csvdecode",
+		"base64encode", "base64decode",
+		"setunion", "setintersection", "setsubtract",
+		"setsymmetricdifference", "setproduct",
+		"index", "parseint",
 		"abs", "min", "max", "floor", "ceil", "pow",
 	}
 	got := stdlib.Functions()
@@ -377,6 +457,40 @@ func TestEvalErrorCases(t *testing.T) {
 			Name: "regex_invalid_pattern",
 			Src:  `locals { out = regex("[unterminated", "abc") }`,
 		},
+		{
+			// base64.go: malformed base64 input → DecodeString error.
+			Name: "base64decode_invalid",
+			Src:  `locals { out = base64decode("not-valid-base64!!!") }`,
+		},
+		{
+			// base64.go: legal base64 that decodes to non-UTF-8 bytes
+			// (0xff is not a valid UTF-8 start byte) hits the utf8.Valid
+			// guard. "/w==" is base64 for [0xff].
+			Name: "base64decode_non_utf8",
+			Src:  `locals { out = base64decode("/w==") }`,
+		},
+		{
+			// jsondecode of malformed JSON surfaces a parse error.
+			Name: "jsondecode_invalid",
+			Src:  `locals { out = jsondecode("{not json") }`,
+		},
+		{
+			// index.go: non-list/tuple input → "argument must be a
+			// list or tuple" error.
+			Name: "index_non_list",
+			Src:  `locals { out = index("not-a-list", "x") }`,
+		},
+		{
+			// index.go: empty list → "cannot search an empty list"
+			// error path.
+			Name: "index_empty_list",
+			Src:  `locals { out = index([], "x") }`,
+		},
+		{
+			// index.go: value not present → "item not found" error.
+			Name: "index_not_found",
+			Src:  `locals { out = index(["a", "b"], "z") }`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -395,20 +509,55 @@ func TestEvalErrorCases(t *testing.T) {
 	}
 }
 
-// TestCoalesceUnknown exercises the IsKnown() short-circuit in
-// coalesce.go: an unknown-typed argument causes the function to
-// return UnknownVal rather than skipping or erroring. Driven through
-// the Function directly because HCL literals are always known.
-func TestCoalesceUnknown(t *testing.T) {
-	got, err := stdlib.Functions()["coalesce"].Call([]cty.Value{
-		cty.UnknownVal(cty.String),
-		cty.StringVal("fallback"),
-	})
-	if err != nil {
-		t.Fatalf("Call: %v", err)
+// TestUnknownInputShortCircuits exercises the IsKnown() short-
+// circuits in coalesce.go and index.go: an unknown-typed argument
+// causes the function to return UnknownVal rather than skipping or
+// erroring. Driven through Function.Call directly because HCL
+// literals are always known.
+func TestUnknownInputShortCircuits(t *testing.T) {
+	cases := []struct {
+		Name string
+		Func string
+		Args []cty.Value
+	}{
+		{
+			Name: "coalesce_unknown_first_arg",
+			Func: "coalesce",
+			Args: []cty.Value{cty.UnknownVal(cty.String), cty.StringVal("fallback")},
+		},
+		{
+			// index.go: unknown list short-circuits to Unknown(Number).
+			Name: "index_unknown_list",
+			Func: "index",
+			Args: []cty.Value{cty.UnknownVal(cty.List(cty.String)), cty.StringVal("x")},
+		},
+		{
+			// index.go: a list containing an unknown element makes
+			// the per-element equality check return unknown for that
+			// position; the iterator hits the !eq.IsKnown() branch
+			// before reaching the known target. Outer list is known
+			// (structurally) so the function machinery passes it into
+			// Impl rather than short-circuiting at the boundary.
+			Name: "index_partially_unknown_list",
+			Func: "index",
+			Args: []cty.Value{
+				cty.ListVal([]cty.Value{
+					cty.UnknownVal(cty.String), cty.StringVal("b"),
+				}),
+				cty.StringVal("b"),
+			},
+		},
 	}
-	if got.IsKnown() {
-		t.Errorf("coalesce(unknown, ...) should return Unknown, got %#v", got)
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			got, err := stdlib.Functions()[tc.Func].Call(tc.Args)
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			if got.IsKnown() {
+				t.Errorf("%s should return Unknown, got %#v", tc.Name, got)
+			}
+		})
 	}
 }
 

--- a/pkg/analysis/stdlib/testdata/base64decode/main.tf
+++ b/pkg/analysis/stdlib/testdata/base64decode/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = base64decode("aGVsbG8=")
+}

--- a/pkg/analysis/stdlib/testdata/base64encode/main.tf
+++ b/pkg/analysis/stdlib/testdata/base64encode/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = base64encode("hello")
+}

--- a/pkg/analysis/stdlib/testdata/csvdecode/main.tf
+++ b/pkg/analysis/stdlib/testdata/csvdecode/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = csvdecode("name,size\nweb,small\ndb,large\n")
+}

--- a/pkg/analysis/stdlib/testdata/index/main.tf
+++ b/pkg/analysis/stdlib/testdata/index/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = index(["a", "b", "c"], "b")
+}

--- a/pkg/analysis/stdlib/testdata/jsondecode/main.tf
+++ b/pkg/analysis/stdlib/testdata/jsondecode/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = jsondecode("{\"a\":1,\"b\":\"two\"}")
+}

--- a/pkg/analysis/stdlib/testdata/jsonencode/main.tf
+++ b/pkg/analysis/stdlib/testdata/jsonencode/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = jsonencode({ a = 1, b = "two" })
+}

--- a/pkg/analysis/stdlib/testdata/parseint/main.tf
+++ b/pkg/analysis/stdlib/testdata/parseint/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = parseint("ff", 16)
+}

--- a/pkg/analysis/stdlib/testdata/setintersection/main.tf
+++ b/pkg/analysis/stdlib/testdata/setintersection/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = setintersection(toset(["a", "b", "c"]), toset(["b", "c", "d"]))
+}

--- a/pkg/analysis/stdlib/testdata/setproduct/main.tf
+++ b/pkg/analysis/stdlib/testdata/setproduct/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = setproduct(["a", "b"], ["x", "y"])
+}

--- a/pkg/analysis/stdlib/testdata/setsubtract/main.tf
+++ b/pkg/analysis/stdlib/testdata/setsubtract/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = setsubtract(toset(["a", "b", "c"]), toset(["b"]))
+}

--- a/pkg/analysis/stdlib/testdata/setsymmetricdifference/main.tf
+++ b/pkg/analysis/stdlib/testdata/setsymmetricdifference/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = setsymmetricdifference(toset(["a", "b"]), toset(["b", "c"]))
+}

--- a/pkg/analysis/stdlib/testdata/setunion/main.tf
+++ b/pkg/analysis/stdlib/testdata/setunion/main.tf
@@ -1,0 +1,3 @@
+locals {
+  out = setunion(toset(["a", "b"]), toset(["b", "c"]))
+}

--- a/pkg/diff/testdata/tracked_eval_jsonencode_collapses/new.tf
+++ b/pkg/diff/testdata/tracked_eval_jsonencode_collapses/new.tf
@@ -1,0 +1,6 @@
+locals {
+  # Refactor: same policy expressed as an HCL object + jsonencode()
+  # rather than a raw string. Effective JSON identical (both keys
+  # serialise in sorted order) → Informational, not Breaking.
+  policy = jsonencode({ Action = "s3:GetObject", Effect = "Allow" }) # tflens:track: IAM policy document
+}

--- a/pkg/diff/testdata/tracked_eval_jsonencode_collapses/old.tf
+++ b/pkg/diff/testdata/tracked_eval_jsonencode_collapses/old.tf
@@ -1,0 +1,3 @@
+locals {
+  policy = "{\"Action\":\"s3:GetObject\",\"Effect\":\"Allow\"}" # tflens:track: IAM policy document
+}

--- a/pkg/diff/tracked_test.go
+++ b/pkg/diff/tracked_test.go
@@ -284,6 +284,18 @@ var trackedCases = []trackedCase{
 		DetailContains: []string{"no effective value change"},
 	},
 	{
+		// Stdlib completion batch (jsonencode): IAM-policy refactor
+		// from raw JSON string → HCL object + jsonencode(). Both
+		// serialise the same key/value pairs in sorted-key order →
+		// effective string identical → Informational, not Breaking.
+		// Most realistic real-world value-collapse use case for the
+		// json family.
+		Name:           "tracked_eval_jsonencode_collapses",
+		Subject:        "local.policy.value",
+		WantKind:       diff.Informational,
+		DetailContains: []string{"no effective value change"},
+	},
+	{
 		Name:           "tracked_literal_value_changed",
 		Subject:        "resource.aws_eks_cluster.this.cluster_version",
 		WantKind:       diff.Breaking,


### PR DESCRIPTION
## Summary

- Wires 12 more Terraform built-ins, bringing the curated set to 60.
- **Encoders / decoders (5)**: `jsonencode`, `jsondecode`, `csvdecode` (direct cty wraps); `base64encode`, `base64decode` (Terraform-side wrappers in `base64.go` — cty doesn't expose them).
- **Set algebra (5)**: `setunion`, `setintersection`, `setsubtract`, `setsymmetricdifference`, `setproduct` (direct cty wraps; common in `for_each` composition).
- **Pickups (2)**: `index` (Terraform-side wrapper in `index.go` — cty's `IndexFunc` is a different function entirely, returns the element AT a given key not the position OF a value); `parseint` (direct cty wrap).
- README's "Static evaluation surface" table updated; previously-listed "plausible for future batches" items reorganised — high-value ones now wired; `formatdate`/`timeadd`/`signum`/`log` move to "Deliberately excluded" with rationale.

## Test plan

- [x] `make check` (vet + test + gofmt) — all packages pass
- [x] 12 per-function fixtures pin happy-path return shapes
- [x] 4 negative-path cases (`base64decode_invalid`, `base64decode_non_utf8`, `jsondecode_invalid`, `index_*`) cover the error branches in the new wrappers
- [x] `index_partially_unknown_list` exercises the unknown-element short-circuit in `index.go`
- [x] End-to-end `tracked_eval_jsonencode_collapses` confirms suppression of the IAM-policy refactor (raw JSON string ↔ HCL object + `jsonencode()`)
- [x] `pkg/analysis/stdlib` package coverage at 100%