### PR TITLE
feat: --format markdown — GitHub-flavoured rendering for diff/whatif/statediff/validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to tflens are documented here. The format is loosely based o
 
 ## [Unreleased]
 
+### Added
+
+- **`--format markdown` — GitHub-flavoured markdown rendering for `diff` / `whatif` / `statediff` / `validate`.** Emits severity badges (🔴 Breaking / 🟡 Non-breaking / 🔵 Informational), collapsible `<details>` sections per module call (open-by-default when the section contains any Breaking change or, for whatif, when the call has direct impact on the caller), inline code-fenced file:line locations, and quoted-block fix hints. Designed for sticky-commenting on PRs (`gh pr comment $PR --body-file -`) and GitHub Actions step summaries (`>> $GITHUB_STEP_SUMMARY`). Single-stream output (warnings stay on stdout, mirroring `--format json`) so the whole document is pipeable. Implemented as `MarkdownRenderer` in `pkg/render/markdown.go` satisfying the existing `Renderer` interface composite — `render.New(s)` dispatches on the new `config.Settings.Markdown` flag. Other subcommands (`cycles`, `deps`, `impact`, `inventory`, `unused`, `cache *`, `fmt`'s parse-error surface) get terse markdown impls so the interface stays satisfied; the rich PR-comment treatment is reserved for the four primary surfaces. 8 golden cases under `pkg/render/testdata/markdown/<case>.golden.md` pin the per-surface output shape (no-changes baselines, mixed-kind diff with fix hints, whatif with direct impact + API diff, statediff with adds/removes/renames + sensitive-change/state orphans, validate mixed errors).
+
 ## [0.8.1] — 2026-04-25
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ Shell completion scripts (bash / zsh / fish / PowerShell) are available via
 Global flags accepted on every subcommand:
 
 - `--format json` — emit structured output on stdout; warnings stay on stderr as plain text, so stdout stays pipeable.
+- `--format markdown` — emit GitHub-flavoured markdown on stdout (severity badges 🔴🟡🔵, collapsible `<details>` per module with the most-severe sections opened by default, code-fenced fix hints inline, file:line as inline backticks). Designed for sticky-commenting on PRs and GitHub Actions step summaries (`>> $GITHUB_STEP_SUMMARY`). Like `--format json`, the whole document is a single stream — warnings stay on stdout — so it can be piped directly into `gh pr comment`. Currently rich for `diff`/`whatif`/`statediff`/`validate`; other subcommands get a terse markdown rendering.
 - `--offline` — disable registry and git fetches; only local paths and `.terraform/modules/modules.json` entries are resolved.
 
 ```
 tflens --format json validate ./my-tf | jq '.cross_module_issues[]'
+tflens --format markdown diff --ref main ./my-tf | gh pr comment $PR --body-file -
 tflens --offline diff --ref main ./my-tf
 ```
 

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -58,9 +58,9 @@ func runFmt(s config.Settings) {
 	p := hclparse.NewParser()
 	if _, diags := p.ParseHCL(src, s.Path); diags.HasErrors() {
 		// Text-mode parse errors stay on stderr to keep stdout pipe-
-		// safe. The JSON envelope goes to stdout as usual.
+		// safe. JSON and markdown go to stdout (single pipeable stream).
 		errSettings := s
-		if !s.JSON {
+		if !s.JSON && !s.Markdown {
 			errSettings.Out = s.Err
 		}
 		render.New(errSettings).FmtParseErrors(diags)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -42,10 +42,11 @@ func runValidate(s config.Settings) {
 	refErrs := mod.Validate()
 	typeErrs := mod.TypeErrors()
 	total := len(refErrs) + len(typeErrs) + len(crossErrs)
-	// Errors go to stderr so they don't pollute pipes; the success
-	// message (and the JSON envelope) stay on stdout. Mutate the
-	// local Settings copy so render.New picks up the right writer.
-	if total > 0 && !s.JSON {
+	// Errors go to stderr so they don't pollute pipes; the JSON and
+	// markdown outputs stay on stdout (single pipeable stream).
+	// Mutate the local Settings copy so render.New picks up the right
+	// writer.
+	if total > 0 && !s.JSON && !s.Markdown {
 		s.Out = s.Err
 	}
 	render.New(s).Validate(refErrs, crossErrs, typeErrs)

--- a/pkg/config/cobra.go
+++ b/pkg/config/cobra.go
@@ -18,6 +18,7 @@ func FromCommand(cmd *cobra.Command, opts ...Option) Settings {
 		Err:       cmd.ErrOrStderr(),
 		Offline:   getBool(cmd, "offline"),
 		JSON:      getString(cmd, "format") == "json",
+		Markdown:  getString(cmd, "format") == "markdown",
 		BaseRef:   getString(cmd, "ref"),
 		StatePath: getString(cmd, "state"),
 		Write:     getBool(cmd, "write"),

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -42,6 +42,12 @@ type Settings struct {
 	// JSON is true when --format=json was given. Subcommands switch
 	// from human-readable rendering to a structured envelope.
 	JSON bool
+	// Markdown is true when --format=markdown was given. The renderer
+	// emits GitHub-flavoured markdown suitable for sticky-commenting on
+	// a PR. Like JSON, the output is a single stream — warnings stay on
+	// stdout rather than splitting to stderr — so the whole document
+	// can be piped into `gh pr comment` or similar.
+	Markdown bool
 
 	// Per-subcommand flags
 

--- a/pkg/render/helpers_test.go
+++ b/pkg/render/helpers_test.go
@@ -26,6 +26,14 @@ func jsonRenderer(w io.Writer) render.Renderer {
 	return render.New(config.Settings{Out: w, JSON: true})
 }
 
+// markdownRenderer returns a markdown-mode render.Renderer that
+// writes to w. Pairs with the per-case .golden.md files under
+// testdata/markdown/ for golden-style assertion of the rendered
+// output.
+func markdownRenderer(w io.Writer) render.Renderer {
+	return render.New(config.Settings{Out: w, Markdown: true})
+}
+
 // moduleFromSrc builds an analysis.Module from inline HCL. Used by
 // the json_test wire-format pinning tests where the input is a
 // one-line resource / data declaration that doesn't justify a

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -1,0 +1,577 @@
+package render
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/dgr237/tflens/pkg/analysis"
+	"github.com/dgr237/tflens/pkg/diff"
+	"github.com/dgr237/tflens/pkg/loader"
+	"github.com/dgr237/tflens/pkg/statediff"
+	"github.com/dgr237/tflens/pkg/token"
+)
+
+// MarkdownRenderer is the GitHub-flavoured markdown Renderer
+// implementation — output is a single stream (warnings stay on stdout
+// rather than splitting to stderr) so the whole document can be piped
+// into `gh pr comment`, GitHub Actions $GITHUB_STEP_SUMMARY, or any
+// markdown-friendly sticky-comment tool.
+//
+// The four ref-comparing surfaces (Diff, Whatif, Statediff) and
+// Validate get the rich treatment — severity badges, collapsible
+// `<details>` sections per module, code-fenced fix hints, file:line
+// as inline backticks. The single-module surfaces (Cycles, Deps,
+// Impact, Inventory, Unused) and the operational ones (Cache*,
+// FmtParseErrors) get terse markdown impls so the Renderer composite
+// stays satisfied — they're rarely useful in PR comments but the
+// interface needs them.
+type MarkdownRenderer struct {
+	W io.Writer
+}
+
+// Severity badges — emoji + text label.  Match GitHub's preferred
+// circle-emoji style for accessibility (text label survives screen
+// readers; emoji gives quick visual scan).
+const (
+	badgeBreaking      = "🔴 Breaking"
+	badgeNonBreaking   = "🟡 Non-breaking"
+	badgeInformational = "🔵 Informational"
+)
+
+func badgeForKind(k diff.ChangeKind) string {
+	switch k {
+	case diff.Breaking:
+		return badgeBreaking
+	case diff.NonBreaking:
+		return badgeNonBreaking
+	case diff.Informational:
+		return badgeInformational
+	}
+	return string(k.String())
+}
+
+// ---- ref-comparing subcommands (the headline use case) ----
+
+func (m *MarkdownRenderer) Diff(
+	baseRef, path string,
+	results []diff.PairResult,
+	rootChanges []diff.Change,
+) {
+	totals := totalsFromResults(results, rootChanges)
+	m.writeHeader("`tflens diff` results", baseRef, path, totals)
+
+	if !totals.any() {
+		fmt.Fprintf(m.W, "**No changes detected vs `%s`.** ✅\n", baseRef)
+		return
+	}
+
+	if len(rootChanges) > 0 {
+		fmt.Fprintln(m.W, "## Root module")
+		fmt.Fprintln(m.W)
+		m.writeChangeList(rootChanges)
+		fmt.Fprintln(m.W)
+	}
+
+	for _, r := range results {
+		if !r.Interesting() {
+			continue
+		}
+		m.writePairResult(r)
+	}
+}
+
+func (m *MarkdownRenderer) Whatif(baseRef, path string, calls []diff.WhatifResult) {
+	// Whatif results are per-module-call. Build a flattened totals row
+	// across all calls' API-changes + direct-impact errors so the
+	// header has the same shape as Diff.
+	totals := changeTotals{}
+	for _, c := range calls {
+		for _, ch := range c.APIChanges {
+			totals.add(ch.Kind)
+		}
+		if len(c.DirectImpact) > 0 {
+			totals.directImpact += len(c.DirectImpact)
+		}
+	}
+	m.writeHeader("`tflens whatif` results", baseRef, path, totals)
+
+	if len(calls) == 0 {
+		fmt.Fprintf(m.W, "**No module calls to evaluate vs `%s`.**\n", baseRef)
+		return
+	}
+
+	for _, c := range calls {
+		m.writeWhatifCall(c)
+	}
+}
+
+func (m *MarkdownRenderer) Statediff(result *statediff.Result) {
+	if result == nil {
+		fmt.Fprintln(m.W, "## `tflens statediff` results")
+		fmt.Fprintln(m.W)
+		fmt.Fprintln(m.W, "No state diff result.")
+		return
+	}
+	flagged := result.FlaggedCount()
+	fmt.Fprintln(m.W, "## `tflens statediff` results")
+	fmt.Fprintln(m.W)
+	if flagged == 0 {
+		fmt.Fprintln(m.W, "**No flagged resources.** ✅")
+		return
+	}
+	fmt.Fprintf(m.W, "**%d flagged item%s.**\n\n", flagged, plural(flagged))
+
+	if len(result.AddedResources) > 0 {
+		fmt.Fprintln(m.W, "### Added resources")
+		fmt.Fprintln(m.W)
+		for _, r := range result.AddedResources {
+			fmt.Fprintf(m.W, "- `%s`\n", r.Address())
+		}
+		fmt.Fprintln(m.W)
+	}
+	if len(result.RemovedResources) > 0 {
+		fmt.Fprintln(m.W, "### Removed resources")
+		fmt.Fprintln(m.W)
+		for _, r := range result.RemovedResources {
+			fmt.Fprintf(m.W, "- `%s`\n", r.Address())
+		}
+		fmt.Fprintln(m.W)
+	}
+	if len(result.RenamedResources) > 0 {
+		fmt.Fprintln(m.W, "### Renamed resources (via `moved` blocks)")
+		fmt.Fprintln(m.W)
+		for _, p := range result.RenamedResources {
+			fmt.Fprintf(m.W, "- `%s` → `%s`\n", p.FromAddress(), p.ToAddress())
+		}
+		fmt.Fprintln(m.W)
+	}
+	if len(result.SensitiveChanges) > 0 {
+		fmt.Fprintln(m.W, "### Sensitive changes reaching count/for_each")
+		fmt.Fprintln(m.W)
+		for _, sc := range result.SensitiveChanges {
+			label := fmt.Sprintf("%s.%s", sc.Kind, sc.Name)
+			if sc.Module != "" {
+				label = sc.Module + "." + label
+			}
+			fmt.Fprintf(m.W, "<details><summary><code>%s</code> changed (`%s` → `%s`)</summary>\n\n",
+				label, displayValue(sc.OldValue), displayValue(sc.NewValue))
+			if len(sc.AffectedResources) > 0 {
+				fmt.Fprintln(m.W, "Affected resources:")
+				fmt.Fprintln(m.W)
+				for _, a := range sc.AffectedResources {
+					fmt.Fprintf(m.W, "- `%s` (via `%s`)\n", a.Address(), a.MetaArg)
+					for _, inst := range a.StateInstances {
+						fmt.Fprintf(m.W, "  - state instance: `%s`\n", inst)
+					}
+				}
+				fmt.Fprintln(m.W)
+			}
+			fmt.Fprintln(m.W, "</details>")
+			fmt.Fprintln(m.W)
+		}
+	}
+	if len(result.StateOrphans) > 0 {
+		fmt.Fprintln(m.W, "### State orphans (in state but not in source)")
+		fmt.Fprintln(m.W)
+		for _, o := range result.StateOrphans {
+			fmt.Fprintf(m.W, "- `%s`\n", o)
+		}
+		fmt.Fprintln(m.W)
+	}
+}
+
+// ---- validate ----
+
+func (m *MarkdownRenderer) Validate(
+	refErrs, crossErrs []analysis.ValidationError,
+	typeErrs []analysis.TypeCheckError,
+) {
+	total := len(refErrs) + len(crossErrs) + len(typeErrs)
+	fmt.Fprintln(m.W, "## `tflens validate` results")
+	fmt.Fprintln(m.W)
+	if total == 0 {
+		fmt.Fprintln(m.W, "**No issues found.** ✅")
+		return
+	}
+	fmt.Fprintf(m.W, "**%d issue%s found.** 🔴\n\n", total, plural(total))
+
+	if len(refErrs) > 0 {
+		fmt.Fprintln(m.W, "### Undefined references")
+		fmt.Fprintln(m.W)
+		for _, e := range refErrs {
+			fmt.Fprintf(m.W, "- `%s` references undeclared `%s` &mdash; %s\n",
+				e.EntityID, e.Ref, locationCode(e.Pos))
+		}
+		fmt.Fprintln(m.W)
+	}
+	if len(crossErrs) > 0 {
+		fmt.Fprintln(m.W, "### Cross-module issues")
+		fmt.Fprintln(m.W)
+		for _, e := range crossErrs {
+			msg := e.Msg
+			if msg == "" {
+				msg = fmt.Sprintf("%s is undefined", e.Ref)
+			}
+			fmt.Fprintf(m.W, "- `%s`: %s &mdash; %s\n", e.EntityID, msg, locationCode(e.Pos))
+		}
+		fmt.Fprintln(m.W)
+	}
+	if len(typeErrs) > 0 {
+		fmt.Fprintln(m.W, "### Type errors")
+		fmt.Fprintln(m.W)
+		for _, e := range typeErrs {
+			attr := ""
+			if e.Attr != "" {
+				attr = fmt.Sprintf(" (`%s`)", e.Attr)
+			}
+			fmt.Fprintf(m.W, "- `%s`%s: %s &mdash; %s\n",
+				e.EntityID, attr, e.Msg, locationCode(e.Pos))
+		}
+		fmt.Fprintln(m.W)
+	}
+}
+
+// ---- single-module surfaces (terse impls) ----
+
+func (m *MarkdownRenderer) Cycles(cycles [][]string) {
+	fmt.Fprintln(m.W, "## Dependency cycles")
+	fmt.Fprintln(m.W)
+	if len(cycles) == 0 {
+		fmt.Fprintln(m.W, "**No cycles detected.** ✅")
+		return
+	}
+	for _, cyc := range cycles {
+		fmt.Fprintf(m.W, "- %s\n", strings.Join(quoteAll(cyc), " → "))
+	}
+}
+
+func (m *MarkdownRenderer) Deps(id string, deps, dependents []string) {
+	fmt.Fprintf(m.W, "## Dependencies of `%s`\n\n", id)
+	fmt.Fprintln(m.W, "**Depends on:**")
+	fmt.Fprintln(m.W)
+	if len(deps) == 0 {
+		fmt.Fprintln(m.W, "- _(none)_")
+	} else {
+		for _, d := range deps {
+			fmt.Fprintf(m.W, "- `%s`\n", d)
+		}
+	}
+	fmt.Fprintln(m.W)
+	fmt.Fprintln(m.W, "**Referenced by:**")
+	fmt.Fprintln(m.W)
+	if len(dependents) == 0 {
+		fmt.Fprintln(m.W, "- _(none)_")
+		return
+	}
+	for _, d := range dependents {
+		fmt.Fprintf(m.W, "- `%s`\n", d)
+	}
+}
+
+func (m *MarkdownRenderer) Impact(id string, affected []string) {
+	fmt.Fprintf(m.W, "## Impact of changing `%s`\n\n", id)
+	if len(affected) == 0 {
+		fmt.Fprintln(m.W, "_No other entities affected._")
+		return
+	}
+	fmt.Fprintf(m.W, "**%d entit%s affected** (topological order):\n\n", len(affected), pluralY(len(affected)))
+	for _, a := range affected {
+		fmt.Fprintf(m.W, "1. `%s`\n", a)
+	}
+}
+
+func (m *MarkdownRenderer) Inventory(mod *analysis.Module) {
+	ents := mod.Entities()
+	fmt.Fprintf(m.W, "## Inventory (%d entit%s)\n\n", len(ents), pluralY(len(ents)))
+	if len(ents) == 0 {
+		fmt.Fprintln(m.W, "_(empty)_")
+		return
+	}
+	fmt.Fprintln(m.W, "| Kind | ID | Location |")
+	fmt.Fprintln(m.W, "| --- | --- | --- |")
+	for _, e := range ents {
+		fmt.Fprintf(m.W, "| %s | `%s` | `%s` |\n", e.Kind, e.ID(), e.Location())
+	}
+}
+
+func (m *MarkdownRenderer) Unused(unused []analysis.Entity) {
+	fmt.Fprintf(m.W, "## Unused entities (%d)\n\n", len(unused))
+	if len(unused) == 0 {
+		fmt.Fprintln(m.W, "**No unused entities.** ✅")
+		return
+	}
+	for _, e := range unused {
+		fmt.Fprintf(m.W, "- `%s` &mdash; `%s`\n", e.ID(), e.Location())
+	}
+}
+
+// ---- cache ----
+
+func (m *MarkdownRenderer) CacheInfo(path string, entries int, bytes int64) {
+	fmt.Fprintln(m.W, "## Cache info")
+	fmt.Fprintln(m.W)
+	fmt.Fprintf(m.W, "- **Path:** `%s`\n", path)
+	fmt.Fprintf(m.W, "- **Entries:** %d\n", entries)
+	fmt.Fprintf(m.W, "- **Size:** %s\n", humanBytes(bytes))
+}
+
+func (m *MarkdownRenderer) CacheAlreadyEmpty(path string) {
+	fmt.Fprintf(m.W, "Cache at `%s` was already empty.\n", path)
+}
+
+func (m *MarkdownRenderer) CacheCleared(entries int, bytes int64, path string) {
+	fmt.Fprintf(m.W, "Cleared %d entr%s (%s) from cache at `%s`.\n",
+		entries, pluralY(entries), humanBytes(bytes), path)
+}
+
+// ---- fmt ----
+
+func (m *MarkdownRenderer) FmtParseErrors(diags hcl.Diagnostics) {
+	fmt.Fprintln(m.W, "## Parse errors")
+	fmt.Fprintln(m.W)
+	for _, d := range diags {
+		var loc string
+		if d.Subject != nil {
+			loc = fmt.Sprintf(" (`%s:%d:%d`)", d.Subject.Filename,
+				d.Subject.Start.Line, d.Subject.Start.Column)
+		}
+		fmt.Fprintf(m.W, "- **%s**: %s%s\n", d.Summary, d.Detail, loc)
+	}
+}
+
+// ---- internal helpers ----
+
+// changeTotals tallies the per-Kind counts plus a directImpact counter
+// for whatif. Renders into a one-liner header summary.
+type changeTotals struct {
+	breaking      int
+	nonBreaking   int
+	informational int
+	directImpact  int
+}
+
+func (t *changeTotals) add(k diff.ChangeKind) {
+	switch k {
+	case diff.Breaking:
+		t.breaking++
+	case diff.NonBreaking:
+		t.nonBreaking++
+	case diff.Informational:
+		t.informational++
+	}
+}
+
+func (t changeTotals) any() bool {
+	return t.breaking+t.nonBreaking+t.informational+t.directImpact > 0
+}
+
+func totalsFromResults(results []diff.PairResult, rootChanges []diff.Change) changeTotals {
+	totals := changeTotals{}
+	for _, ch := range rootChanges {
+		totals.add(ch.Kind)
+	}
+	for _, r := range results {
+		for _, ch := range r.Changes {
+			totals.add(ch.Kind)
+		}
+	}
+	return totals
+}
+
+// writeHeader emits the title + base-ref + summary line shared by Diff
+// and Whatif. The summary line uses the badge constants so a quick
+// scan tells you what severity to expect before diving into details.
+func (m *MarkdownRenderer) writeHeader(title, baseRef, path string, t changeTotals) {
+	fmt.Fprintf(m.W, "## %s\n\n", title)
+	fmt.Fprintf(m.W, "_Base ref: `%s` &middot; Path: `%s`_\n\n", baseRef, path)
+	if t.any() {
+		var parts []string
+		if t.breaking > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", t.breaking, badgeBreaking))
+		}
+		if t.nonBreaking > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", t.nonBreaking, badgeNonBreaking))
+		}
+		if t.informational > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", t.informational, badgeInformational))
+		}
+		if t.directImpact > 0 {
+			parts = append(parts, fmt.Sprintf("%d direct impact", t.directImpact))
+		}
+		fmt.Fprintf(m.W, "**Summary:** %s\n\n", strings.Join(parts, ", "))
+	}
+}
+
+// writePairResult emits one paired-call section. Added/Removed get
+// short single-line headings; Changed gets a `<details>` collapsible
+// with the per-Kind change list.
+func (m *MarkdownRenderer) writePairResult(r diff.PairResult) {
+	switch r.Pair.Status {
+	case loader.StatusAdded:
+		fmt.Fprintf(m.W, "### Module `%s` &mdash; **ADDED** (source `%s`",
+			r.Pair.Key, r.Pair.NewSource)
+		if r.Pair.NewVersion != "" {
+			fmt.Fprintf(m.W, ", version `%s`", r.Pair.NewVersion)
+		}
+		fmt.Fprintln(m.W, ")")
+		fmt.Fprintln(m.W)
+		return
+	case loader.StatusRemoved:
+		fmt.Fprintf(m.W, "### Module `%s` &mdash; **REMOVED** (was source `%s`",
+			r.Pair.Key, r.Pair.OldSource)
+		if r.Pair.OldVersion != "" {
+			fmt.Fprintf(m.W, ", version `%s`", r.Pair.OldVersion)
+		}
+		fmt.Fprintln(m.W, ")")
+		fmt.Fprintln(m.W)
+		return
+	}
+
+	// changed
+	openSummary := fmt.Sprintf("Module <code>%s</code>", r.Pair.Key)
+	if r.Pair.OldSource != r.Pair.NewSource {
+		openSummary += fmt.Sprintf(" &mdash; source <code>%s</code> → <code>%s</code>",
+			r.Pair.OldSource, r.Pair.NewSource)
+	}
+	if r.Pair.OldVersion != r.Pair.NewVersion {
+		openSummary += fmt.Sprintf(" &mdash; version <code>%s</code> → <code>%s</code>",
+			r.Pair.OldVersion, r.Pair.NewVersion)
+	}
+	if len(r.Changes) == 0 {
+		fmt.Fprintf(m.W, "### %s\n\n_(no API changes)_\n\n", openSummary)
+		return
+	}
+
+	// Collapsed by default for non-Breaking-only sections; opened by
+	// default when the section contains any Breaking change so the
+	// PR reviewer sees the most important info immediately.
+	openAttr := ""
+	for _, ch := range r.Changes {
+		if ch.Kind == diff.Breaking {
+			openAttr = " open"
+			break
+		}
+	}
+	fmt.Fprintf(m.W, "<details%s><summary>%s</summary>\n\n", openAttr, openSummary)
+	m.writeChangeList(r.Changes)
+	fmt.Fprintln(m.W, "</details>")
+	fmt.Fprintln(m.W)
+}
+
+// writeWhatifCall emits one whatif call section. Direct-impact gets a
+// 🔴 prefix so reviewers spot the gating signal at a glance.
+func (m *MarkdownRenderer) writeWhatifCall(c diff.WhatifResult) {
+	directImpact := len(c.DirectImpact) > 0
+	prefix := ""
+	if directImpact {
+		prefix = "🔴 "
+	}
+	heading := fmt.Sprintf("%sModule `%s`", prefix, c.Pair.Key)
+	if c.Pair.OldVersion != "" || c.Pair.NewVersion != "" {
+		heading += fmt.Sprintf(" &mdash; version `%s` → `%s`",
+			c.Pair.OldVersion, c.Pair.NewVersion)
+	}
+	if len(c.APIChanges) == 0 && !directImpact {
+		fmt.Fprintf(m.W, "### %s\n\n_(no consumer-affecting changes)_\n\n", heading)
+		return
+	}
+	openAttr := ""
+	if directImpact {
+		openAttr = " open"
+	}
+	fmt.Fprintf(m.W, "<details%s><summary>%s</summary>\n\n", openAttr, heading)
+	if directImpact {
+		fmt.Fprintln(m.W, "**Direct impact on this caller:**")
+		fmt.Fprintln(m.W)
+		for _, e := range c.DirectImpact {
+			msg := e.Msg
+			if msg == "" {
+				msg = fmt.Sprintf("%s is undefined", e.Ref)
+			}
+			fmt.Fprintf(m.W, "- `%s`: %s\n", e.EntityID, msg)
+		}
+		fmt.Fprintln(m.W)
+	}
+	if len(c.APIChanges) > 0 {
+		if directImpact {
+			fmt.Fprintln(m.W, "**Full API diff:**")
+			fmt.Fprintln(m.W)
+		}
+		m.writeChangeList(c.APIChanges)
+	}
+	fmt.Fprintln(m.W, "</details>")
+	fmt.Fprintln(m.W)
+}
+
+// writeChangeList formats a slice of Change as a markdown bullet list,
+// grouped by Kind (Breaking → NonBreaking → Informational), with each
+// entry showing severity badge, subject as inline code, detail, and
+// (when present) a fix hint as a code-fenced block.
+func (m *MarkdownRenderer) writeChangeList(changes []diff.Change) {
+	// Sort by kind so the list reads severity-first regardless of
+	// upstream ordering.
+	sorted := append([]diff.Change(nil), changes...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Kind < sorted[j].Kind
+	})
+	for _, ch := range sorted {
+		fmt.Fprintf(m.W, "- %s &mdash; `%s`: %s\n", badgeForKind(ch.Kind), ch.Subject, ch.Detail)
+		if ch.Hint != "" {
+			fmt.Fprintf(m.W, "  > **Fix:** %s\n", ch.Hint)
+		}
+	}
+	fmt.Fprintln(m.W)
+}
+
+// locationCode renders a token.Position as inline code suitable for
+// embedding in a list item — empty when the position is zero.
+func locationCode(p token.Position) string {
+	if p.File == "" && p.Line == 0 {
+		return ""
+	}
+	if p.File == "" {
+		return fmt.Sprintf("`:%d`", p.Line)
+	}
+	return fmt.Sprintf("`%s:%d`", p.File, p.Line)
+}
+
+// quoteAll wraps each string in backticks for inline-code rendering.
+// Used by Cycles to make the cycle path readable.
+func quoteAll(ss []string) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = "`" + s + "`"
+	}
+	return out
+}
+
+// plural returns "s" when n != 1 (for words like "issue").
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// pluralY returns "y" when n == 1 and "ies" otherwise (for words like
+// "entity"/"entries").
+func pluralY(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}
+
+// displayValue renders a sensitive-change value for the markdown
+// summary — empty strings become the literal "(absent)" so collapsed
+// summaries stay readable.
+func displayValue(v string) string {
+	if v == "" {
+		return "(absent)"
+	}
+	return v
+}

--- a/pkg/render/markdown_test.go
+++ b/pkg/render/markdown_test.go
@@ -1,0 +1,263 @@
+package render_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/dgr237/tflens/pkg/analysis"
+	"github.com/dgr237/tflens/pkg/diff"
+	"github.com/dgr237/tflens/pkg/loader"
+	"github.com/dgr237/tflens/pkg/statediff"
+	"github.com/dgr237/tflens/pkg/token"
+)
+
+// markdownCase runs one MarkdownRenderer scenario through a thunk and
+// matches the captured bytes against testdata/markdown/<Name>.golden.md.
+// Each test passes its inputs inline via the Run thunk so cases can
+// exercise different renderer methods (Diff/Whatif/Statediff/Validate)
+// from one harness — markdown's value is in PR-comment shape, so we
+// pin every primary surface.
+type markdownCase struct {
+	Name string
+	Run  func(r interface {
+		Diff(baseRef, path string, results []diff.PairResult, rootChanges []diff.Change)
+		Whatif(baseRef, path string, calls []diff.WhatifResult)
+		Statediff(result *statediff.Result)
+		Validate(refErrs, crossErrs []analysis.ValidationError, typeErrs []analysis.TypeCheckError)
+	})
+}
+
+// TestRendererMarkdownCases exercises the four primary surfaces
+// through inline scenarios and matches against per-case
+// testdata/markdown/<Name>.golden.md files. Update with `go test
+// ./pkg/render/... -run TestRendererMarkdownCases -update`.
+func TestRendererMarkdownCases(t *testing.T) {
+	for _, tc := range markdownCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var b bytes.Buffer
+			r := markdownRenderer(&b)
+			tc.Run(r)
+			checkMarkdownGolden(t, tc.Name, b.Bytes())
+		})
+	}
+}
+
+var markdownCases = []markdownCase{
+	{
+		// Diff baseline: no changes anywhere → emits the ✅ summary
+		// line and nothing else.
+		Name: "diff_no_changes",
+		Run: func(r interface {
+			Diff(string, string, []diff.PairResult, []diff.Change)
+			Whatif(string, string, []diff.WhatifResult)
+			Statediff(*statediff.Result)
+			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
+		}) {
+			r.Diff("main", "./infra", nil, nil)
+		},
+	},
+	{
+		// Diff with mixed-kind root + module sections — exercises
+		// severity badges, summary totals, the open=open attribute
+		// on Breaking-containing details, and the fix-hint emission.
+		Name: "diff_mixed_changes",
+		Run: func(r interface {
+			Diff(string, string, []diff.PairResult, []diff.Change)
+			Whatif(string, string, []diff.WhatifResult)
+			Statediff(*statediff.Result)
+			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
+		}) {
+			r.Diff("main", "./infra",
+				[]diff.PairResult{{
+					Pair: loader.ModuleCallPair{
+						Key: "vpc", Status: loader.StatusChanged,
+						OldSource: "ns/vpc/aws", NewSource: "ns/vpc/aws",
+						OldVersion: "1.0.0", NewVersion: "2.0.0",
+					},
+					Changes: []diff.Change{
+						{Kind: diff.Breaking, Subject: "var.required", Detail: "removed",
+							Hint: "callers passing this variable will fail"},
+						{Kind: diff.NonBreaking, Subject: "var.tags", Detail: "added optional"},
+						{Kind: diff.Informational, Subject: "out.docs", Detail: "description updated"},
+					},
+				}, {
+					Pair: loader.ModuleCallPair{
+						Key: "eks", Status: loader.StatusAdded,
+						NewSource: "terraform-aws-modules/eks/aws", NewVersion: "20.0.0",
+					},
+				}},
+				[]diff.Change{
+					{Kind: diff.Breaking, Subject: "variable.cluster_name",
+						Detail: "required variable added",
+						Hint:   "add `cluster_name = ...` to the root invocation"},
+				})
+		},
+	},
+	{
+		// Whatif with a direct-impact call: red prefix on the heading,
+		// open=open on the details, "Direct impact" subsection, and
+		// the full API diff section labelled.
+		Name: "whatif_direct_impact",
+		Run: func(r interface {
+			Diff(string, string, []diff.PairResult, []diff.Change)
+			Whatif(string, string, []diff.WhatifResult)
+			Statediff(*statediff.Result)
+			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
+		}) {
+			r.Whatif("main", "./infra", []diff.WhatifResult{{
+				Pair: loader.ModuleCallPair{
+					Key: "vpc", Status: loader.StatusChanged,
+					OldVersion: "1.0.0", NewVersion: "2.0.0",
+				},
+				DirectImpact: []analysis.ValidationError{{
+					EntityID: "module.vpc",
+					Ref:      "var.removed_input",
+					Msg:      "child no longer accepts argument",
+				}},
+				APIChanges: []diff.Change{
+					{Kind: diff.Breaking, Subject: "var.removed_input", Detail: "removed"},
+				},
+			}})
+		},
+	},
+	{
+		// Whatif with no impact + no API changes → "(no consumer-
+		// affecting changes)" baseline.
+		Name: "whatif_clean_upgrade",
+		Run: func(r interface {
+			Diff(string, string, []diff.PairResult, []diff.Change)
+			Whatif(string, string, []diff.WhatifResult)
+			Statediff(*statediff.Result)
+			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
+		}) {
+			r.Whatif("main", "./infra", []diff.WhatifResult{{
+				Pair: loader.ModuleCallPair{
+					Key: "vpc", Status: loader.StatusChanged,
+					OldVersion: "1.0.0", NewVersion: "1.0.1",
+				},
+			}})
+		},
+	},
+	{
+		// Statediff with everything: added/removed/renamed resources +
+		// a sensitive change with affected resources + state instances
+		// + a state orphan. Pins the full multi-section shape.
+		Name: "statediff_full",
+		Run: func(r interface {
+			Diff(string, string, []diff.PairResult, []diff.Change)
+			Whatif(string, string, []diff.WhatifResult)
+			Statediff(*statediff.Result)
+			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
+		}) {
+			r.Statediff(&statediff.Result{
+				BaseRef: "main",
+				Path:    "./infra",
+				AddedResources: []statediff.ResourceRef{
+					{Type: "aws_s3_bucket", Name: "logs", Mode: "managed"},
+				},
+				RemovedResources: []statediff.ResourceRef{
+					{Type: "aws_iam_user", Name: "old", Mode: "managed"},
+				},
+				RenamedResources: []statediff.RenamePair{
+					{From: "resource.aws_vpc.main", To: "resource.aws_vpc.primary"},
+				},
+				SensitiveChanges: []statediff.SensitiveChange{{
+					Kind: "local", Name: "regions",
+					OldValue: `["us-east-1"]`, NewValue: `["us-east-1","us-west-2"]`,
+					AffectedResources: []statediff.AffectedResource{{
+						Type: "aws_subnet", Name: "per_region", MetaArg: "for_each",
+						StateInstances: []string{`aws_subnet.per_region["us-east-1"]`},
+					}},
+				}},
+				StateOrphans: []string{"aws_security_group.legacy"},
+			})
+		},
+	},
+	{
+		// Statediff with no findings → ✅ baseline.
+		Name: "statediff_clean",
+		Run: func(r interface {
+			Diff(string, string, []diff.PairResult, []diff.Change)
+			Whatif(string, string, []diff.WhatifResult)
+			Statediff(*statediff.Result)
+			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
+		}) {
+			r.Statediff(&statediff.Result{BaseRef: "main", Path: "./infra"})
+		},
+	},
+	{
+		// Validate with a mix of error kinds → all three subsections
+		// (undefined refs, cross-module, type errors) plus the
+		// total-count summary line.
+		Name: "validate_mixed_errors",
+		Run: func(r interface {
+			Diff(string, string, []diff.PairResult, []diff.Change)
+			Whatif(string, string, []diff.WhatifResult)
+			Statediff(*statediff.Result)
+			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
+		}) {
+			r.Validate(
+				[]analysis.ValidationError{{
+					EntityID: "resource.aws_vpc.main",
+					Ref:      "var.typo",
+					Pos:      token.Position{File: "main.tf", Line: 12},
+				}},
+				[]analysis.ValidationError{{
+					EntityID: "module.vpc",
+					Msg:      "child requires `region` but root passes `regions`",
+					Pos:      token.Position{File: "main.tf", Line: 5},
+				}},
+				[]analysis.TypeCheckError{{
+					EntityID: "variable.count",
+					Attr:     "default",
+					Msg:      "default value `\"three\"` is string, declared type number",
+					Pos:      token.Position{File: "variables.tf", Line: 3},
+				}},
+			)
+		},
+	},
+	{
+		// Validate clean → ✅ baseline.
+		Name: "validate_clean",
+		Run: func(r interface {
+			Diff(string, string, []diff.PairResult, []diff.Change)
+			Whatif(string, string, []diff.WhatifResult)
+			Statediff(*statediff.Result)
+			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
+		}) {
+			r.Validate(nil, nil, nil)
+		},
+	},
+}
+
+// checkMarkdownGolden compares got against
+// testdata/markdown/<name>.golden.md. Reuses the shared `-update`
+// flag so `go test ./pkg/render/... -run TestRendererMarkdownCases
+// -update` regenerates every golden in one pass.
+//
+// .md extension (vs .golden) so editors syntax-highlight the goldens
+// as markdown — useful when visually reviewing what a regenerate
+// changed.
+func checkMarkdownGolden(t *testing.T, name string, got []byte) {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(file), "testdata", "markdown", name+".golden.md")
+	if *updateGoldens {
+		if err := os.WriteFile(path, got, 0o644); err != nil {
+			t.Fatalf("write golden %s: %v", path, err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v\n(rerun with -update to create it)", path, err)
+	}
+	want = bytes.ReplaceAll(want, []byte("\r\n"), []byte("\n"))
+	if !bytes.Equal(got, want) {
+		t.Errorf("output mismatch for markdown/%s.golden.md\n--- want ---\n%s\n--- got ---\n%s",
+			name, want, got)
+	}
+}

--- a/pkg/render/markdown_test.go
+++ b/pkg/render/markdown_test.go
@@ -7,27 +7,25 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
+
 	"github.com/dgr237/tflens/pkg/analysis"
 	"github.com/dgr237/tflens/pkg/diff"
 	"github.com/dgr237/tflens/pkg/loader"
+	"github.com/dgr237/tflens/pkg/render"
 	"github.com/dgr237/tflens/pkg/statediff"
 	"github.com/dgr237/tflens/pkg/token"
 )
 
 // markdownCase runs one MarkdownRenderer scenario through a thunk and
 // matches the captured bytes against testdata/markdown/<Name>.golden.md.
-// Each test passes its inputs inline via the Run thunk so cases can
-// exercise different renderer methods (Diff/Whatif/Statediff/Validate)
-// from one harness — markdown's value is in PR-comment shape, so we
-// pin every primary surface.
+// Run takes the full render.Renderer so cases can exercise any of the
+// 13 interface methods — markdown's value is in PR-comment shape, so
+// we pin every surface (rich for Diff/Whatif/Statediff/Validate, terse
+// for the rest).
 type markdownCase struct {
 	Name string
-	Run  func(r interface {
-		Diff(baseRef, path string, results []diff.PairResult, rootChanges []diff.Change)
-		Whatif(baseRef, path string, calls []diff.WhatifResult)
-		Statediff(result *statediff.Result)
-		Validate(refErrs, crossErrs []analysis.ValidationError, typeErrs []analysis.TypeCheckError)
-	})
+	Run  func(r render.Renderer)
 }
 
 // TestRendererMarkdownCases exercises the four primary surfaces
@@ -50,12 +48,7 @@ var markdownCases = []markdownCase{
 		// Diff baseline: no changes anywhere → emits the ✅ summary
 		// line and nothing else.
 		Name: "diff_no_changes",
-		Run: func(r interface {
-			Diff(string, string, []diff.PairResult, []diff.Change)
-			Whatif(string, string, []diff.WhatifResult)
-			Statediff(*statediff.Result)
-			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
-		}) {
+		Run: func(r render.Renderer) {
 			r.Diff("main", "./infra", nil, nil)
 		},
 	},
@@ -64,12 +57,7 @@ var markdownCases = []markdownCase{
 		// severity badges, summary totals, the open=open attribute
 		// on Breaking-containing details, and the fix-hint emission.
 		Name: "diff_mixed_changes",
-		Run: func(r interface {
-			Diff(string, string, []diff.PairResult, []diff.Change)
-			Whatif(string, string, []diff.WhatifResult)
-			Statediff(*statediff.Result)
-			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
-		}) {
+		Run: func(r render.Renderer) {
 			r.Diff("main", "./infra",
 				[]diff.PairResult{{
 					Pair: loader.ModuleCallPair{
@@ -101,12 +89,7 @@ var markdownCases = []markdownCase{
 		// open=open on the details, "Direct impact" subsection, and
 		// the full API diff section labelled.
 		Name: "whatif_direct_impact",
-		Run: func(r interface {
-			Diff(string, string, []diff.PairResult, []diff.Change)
-			Whatif(string, string, []diff.WhatifResult)
-			Statediff(*statediff.Result)
-			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
-		}) {
+		Run: func(r render.Renderer) {
 			r.Whatif("main", "./infra", []diff.WhatifResult{{
 				Pair: loader.ModuleCallPair{
 					Key: "vpc", Status: loader.StatusChanged,
@@ -127,12 +110,7 @@ var markdownCases = []markdownCase{
 		// Whatif with no impact + no API changes → "(no consumer-
 		// affecting changes)" baseline.
 		Name: "whatif_clean_upgrade",
-		Run: func(r interface {
-			Diff(string, string, []diff.PairResult, []diff.Change)
-			Whatif(string, string, []diff.WhatifResult)
-			Statediff(*statediff.Result)
-			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
-		}) {
+		Run: func(r render.Renderer) {
 			r.Whatif("main", "./infra", []diff.WhatifResult{{
 				Pair: loader.ModuleCallPair{
 					Key: "vpc", Status: loader.StatusChanged,
@@ -146,12 +124,7 @@ var markdownCases = []markdownCase{
 		// a sensitive change with affected resources + state instances
 		// + a state orphan. Pins the full multi-section shape.
 		Name: "statediff_full",
-		Run: func(r interface {
-			Diff(string, string, []diff.PairResult, []diff.Change)
-			Whatif(string, string, []diff.WhatifResult)
-			Statediff(*statediff.Result)
-			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
-		}) {
+		Run: func(r render.Renderer) {
 			r.Statediff(&statediff.Result{
 				BaseRef: "main",
 				Path:    "./infra",
@@ -179,12 +152,7 @@ var markdownCases = []markdownCase{
 	{
 		// Statediff with no findings → ✅ baseline.
 		Name: "statediff_clean",
-		Run: func(r interface {
-			Diff(string, string, []diff.PairResult, []diff.Change)
-			Whatif(string, string, []diff.WhatifResult)
-			Statediff(*statediff.Result)
-			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
-		}) {
+		Run: func(r render.Renderer) {
 			r.Statediff(&statediff.Result{BaseRef: "main", Path: "./infra"})
 		},
 	},
@@ -193,12 +161,7 @@ var markdownCases = []markdownCase{
 		// (undefined refs, cross-module, type errors) plus the
 		// total-count summary line.
 		Name: "validate_mixed_errors",
-		Run: func(r interface {
-			Diff(string, string, []diff.PairResult, []diff.Change)
-			Whatif(string, string, []diff.WhatifResult)
-			Statediff(*statediff.Result)
-			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
-		}) {
+		Run: func(r render.Renderer) {
 			r.Validate(
 				[]analysis.ValidationError{{
 					EntityID: "resource.aws_vpc.main",
@@ -222,15 +185,298 @@ var markdownCases = []markdownCase{
 	{
 		// Validate clean → ✅ baseline.
 		Name: "validate_clean",
-		Run: func(r interface {
-			Diff(string, string, []diff.PairResult, []diff.Change)
-			Whatif(string, string, []diff.WhatifResult)
-			Statediff(*statediff.Result)
-			Validate([]analysis.ValidationError, []analysis.ValidationError, []analysis.TypeCheckError)
-		}) {
+		Run: func(r render.Renderer) {
 			r.Validate(nil, nil, nil)
 		},
 	},
+
+	// ---- Diff missing-branch coverage ----
+
+	{
+		// Removed pair gets a single short heading line, no details
+		// block. Pins the StatusRemoved branch + version-suffix
+		// emission inside writePairResult.
+		Name: "diff_pair_removed",
+		Run: func(r render.Renderer) {
+			r.Diff("main", "./infra", []diff.PairResult{{
+				Pair: loader.ModuleCallPair{
+					Key: "vpc", Status: loader.StatusRemoved,
+					OldSource: "ns/vpc/aws", OldVersion: "1.0.0",
+				},
+			}}, nil)
+		},
+	},
+	{
+		// Changed pair where source + version are identical and
+		// Changes is empty — the pair filters as uninteresting AND
+		// the no-API-changes branch in writePairResult is moot.
+		// Confirms the "no changes" baseline triggers.
+		Name: "diff_only_uninteresting_pair",
+		Run: func(r render.Renderer) {
+			r.Diff("main", "./infra", []diff.PairResult{{
+				Pair: loader.ModuleCallPair{
+					Key: "vpc", Status: loader.StatusChanged,
+					OldSource: "x", NewSource: "x",
+				},
+			}}, nil)
+		},
+	},
+	{
+		// Source moved but Changes is empty — emits "(no API
+		// changes)" inside the section. Hits the empty-changes
+		// branch of writePairResult that diff_mixed_changes doesn't.
+		Name: "diff_changed_no_api_changes",
+		Run: func(r render.Renderer) {
+			r.Diff("main", "./infra", []diff.PairResult{{
+				Pair: loader.ModuleCallPair{
+					Key: "vpc", Status: loader.StatusChanged,
+					OldSource: "x", NewSource: "y",
+				},
+			}}, nil)
+		},
+	},
+
+	// ---- Statediff missing-branch coverage ----
+
+	{
+		// nil result hits the early-return guard before FlaggedCount.
+		Name: "statediff_nil_result",
+		Run: func(r render.Renderer) {
+			r.Statediff(nil)
+		},
+	},
+
+	// ---- Secondary surfaces (full coverage of the terse impls) ----
+
+	{
+		// Cycles with a non-empty list — exercises quoteAll +
+		// the multi-step cycle rendering. Single-cycle is enough
+		// for the format pin.
+		Name: "cycles_present",
+		Run: func(r render.Renderer) {
+			r.Cycles([][]string{
+				{"resource.aws_a.x", "resource.aws_b.y", "resource.aws_a.x"},
+			})
+		},
+	},
+	{
+		// Cycles empty → ✅ baseline.
+		Name: "cycles_clean",
+		Run: func(r render.Renderer) {
+			r.Cycles(nil)
+		},
+	},
+	{
+		// Deps with both populated — pins the "Depends on" /
+		// "Referenced by" sub-section ordering and bullet shape.
+		Name: "deps_populated",
+		Run: func(r render.Renderer) {
+			r.Deps("resource.aws_vpc.main",
+				[]string{"variable.cidr"},
+				[]string{"resource.aws_subnet.a", "resource.aws_subnet.b"})
+		},
+	},
+	{
+		// Deps with both empty — pins the "_(none)_" italic markers
+		// in both sub-sections.
+		Name: "deps_empty",
+		Run: func(r render.Renderer) {
+			r.Deps("resource.aws_vpc.main", nil, nil)
+		},
+	},
+	{
+		// Impact with affected entities — exercises pluralY ("ies"
+		// branch for n != 1) and the numbered-list rendering.
+		Name: "impact_multiple",
+		Run: func(r render.Renderer) {
+			r.Impact("variable.cidr", []string{
+				"resource.aws_vpc.main",
+				"resource.aws_subnet.a",
+			})
+		},
+	},
+	{
+		// Impact with one affected entity — pluralY's "y" branch.
+		Name: "impact_single",
+		Run: func(r render.Renderer) {
+			r.Impact("variable.cidr", []string{"resource.aws_vpc.main"})
+		},
+	},
+	{
+		// Impact with no affected entities — italic baseline.
+		Name: "impact_none",
+		Run: func(r render.Renderer) {
+			r.Impact("variable.unused", nil)
+		},
+	},
+	{
+		// Inventory with entities — pins the markdown-table format.
+		Name: "inventory_populated",
+		Run: func(r render.Renderer) {
+			r.Inventory(moduleFromSrc(t__noopT(),
+				`variable "x" { type = string }
+resource "aws_vpc" "main" {}`))
+		},
+	},
+	{
+		// Inventory empty — italic baseline.
+		Name: "inventory_empty",
+		Run: func(r render.Renderer) {
+			r.Inventory(moduleFromSrc(t__noopT(), ``))
+		},
+	},
+	{
+		// Unused with entities — bullet list with location.
+		Name: "unused_populated",
+		Run: func(r render.Renderer) {
+			r.Unused([]analysis.Entity{
+				{Kind: analysis.KindLocal, Name: "dead_code",
+					Pos: token.Position{File: "main.tf", Line: 5}},
+			})
+		},
+	},
+	{
+		// Unused empty — ✅ baseline.
+		Name: "unused_empty",
+		Run: func(r render.Renderer) {
+			r.Unused(nil)
+		},
+	},
+	{
+		// CacheInfo with entries — exercises humanBytes formatting
+		// (KB/MB humanisation) plus the bullet-list rendering.
+		Name: "cache_info_populated",
+		Run: func(r render.Renderer) {
+			r.CacheInfo("/tmp/tflens-cache", 42, 1024*1024*5+512*1024)
+		},
+	},
+	{
+		// CacheAlreadyEmpty — single short line.
+		Name: "cache_already_empty",
+		Run: func(r render.Renderer) {
+			r.CacheAlreadyEmpty("/tmp/tflens-cache")
+		},
+	},
+	{
+		// CacheCleared — pluralY's "y" branch (1 entry) + humanBytes.
+		Name: "cache_cleared_one",
+		Run: func(r render.Renderer) {
+			r.CacheCleared(1, 4096, "/tmp/tflens-cache")
+		},
+	},
+	{
+		// CacheCleared — pluralY's "ies" branch (multi-entry).
+		Name: "cache_cleared_many",
+		Run: func(r render.Renderer) {
+			r.CacheCleared(7, 1024*1024, "/tmp/tflens-cache")
+		},
+	},
+	{
+		// FmtParseErrors with one diag carrying a Subject (file:pos)
+		// + one without — pins both formatting branches.
+		Name: "fmt_parse_errors",
+		Run: func(r render.Renderer) {
+			r.FmtParseErrors(hcl.Diagnostics{
+				{
+					Severity: hcl.DiagError,
+					Summary:  "Unexpected token",
+					Detail:   "Expected `}`, found `=`",
+					Subject:  &hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 12, Column: 5}},
+				},
+				{
+					Severity: hcl.DiagError,
+					Summary:  "Generic error",
+					Detail:   "Something went wrong",
+				},
+			})
+		},
+	},
+}
+
+// ---- branch-coverage micro-cases ----
+//
+// These pin edge branches that the larger fixtures don't naturally
+// hit (single-issue plural form, empty sensitive values, location
+// with no file path, etc.). Kept here so the same -update flag
+// regenerates everything in one pass.
+
+var markdownMicroCases = []markdownCase{
+	{
+		// Validate with exactly one error → "1 issue found" hits
+		// plural's n==1 branch (returns "" for "issues" → "issue").
+		Name: "validate_single_error",
+		Run: func(r render.Renderer) {
+			r.Validate(
+				[]analysis.ValidationError{{
+					EntityID: "resource.aws_vpc.main",
+					Ref:      "var.typo",
+					Pos:      token.Position{File: "main.tf", Line: 12},
+				}},
+				nil, nil,
+			)
+		},
+	},
+	{
+		// Validate with a position carrying line but no file →
+		// hits locationCode's File=="" && Line!=0 branch.
+		Name: "validate_no_file_position",
+		Run: func(r render.Renderer) {
+			r.Validate(
+				[]analysis.ValidationError{{
+					EntityID: "resource.aws_vpc.main",
+					Ref:      "var.typo",
+					Pos:      token.Position{Line: 12}, // no File
+				}},
+				nil, nil,
+			)
+		},
+	},
+	{
+		// Statediff sensitive change with empty old and new values →
+		// displayValue's empty-branch returns "(absent)" twice.
+		Name: "statediff_sensitive_empty_values",
+		Run: func(r render.Renderer) {
+			r.Statediff(&statediff.Result{
+				BaseRef: "main", Path: "./infra",
+				SensitiveChanges: []statediff.SensitiveChange{{
+					Kind: "variable", Name: "absent_default",
+					Module: "module.api",
+				}},
+			})
+		},
+	},
+}
+
+// TestRendererMarkdownMicroCases runs the small branch-coverage
+// fixtures through the same harness as TestRendererMarkdownCases.
+// Split out from the main table because they're noise from a
+// "what does the markdown look like" perspective — they exist to
+// pin defensive branches, not to demonstrate output shape.
+func TestRendererMarkdownMicroCases(t *testing.T) {
+	for _, tc := range markdownMicroCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var b bytes.Buffer
+			r := markdownRenderer(&b)
+			tc.Run(r)
+			checkMarkdownGolden(t, tc.Name, b.Bytes())
+		})
+	}
+}
+
+// t__noopT returns a *testing.T-shaped value that moduleFromSrc can
+// take. moduleFromSrc requires a *testing.T to call Helper() and
+// Fatalf(); when used inside the markdown table cases (which run
+// later, inside the per-case t.Run), passing the inner-t around is
+// awkward — the cases are static. We synthesise a no-op via a
+// throwaway test instance: moduleFromSrc never fails for the inputs
+// we feed it (well-formed HCL), so the *testing.T is only used for
+// the success path's no-op Helper().
+//
+// If the input HCL ever fails to parse, the panic from a nil-method
+// call will make the failure obvious enough — these are tightly-
+// scoped fixtures, not production inputs.
+func t__noopT() *testing.T {
+	return &testing.T{}
 }
 
 // checkMarkdownGolden compares got against

--- a/pkg/render/renderer.go
+++ b/pkg/render/renderer.go
@@ -66,16 +66,20 @@ type Renderer interface {
 	FmtRenderer
 }
 
-// New returns the renderer matching s.JSON. The Settings supplies
-// both the output writer (s.Out) and the format choice — callers
-// don't need to pass them separately.
+// New returns the renderer matching s.Markdown / s.JSON, defaulting
+// to console. The Settings supplies both the output writer (s.Out)
+// and the format choice — callers don't need to pass them separately.
 //
 // validate's "errors found" branch flips s.Out to s.Err on a copy of
 // Settings before calling New, so the renderer's text output lands
 // on stderr without complicating this constructor.
 func New(s config.Settings) Renderer {
-	if s.JSON {
+	switch {
+	case s.Markdown:
+		return &MarkdownRenderer{W: s.Out}
+	case s.JSON:
 		return &JSONRenderer{W: s.Out}
+	default:
+		return &ConsoleRenderer{W: s.Out}
 	}
-	return &ConsoleRenderer{W: s.Out}
 }

--- a/pkg/render/testdata/markdown/cache_already_empty.golden.md
+++ b/pkg/render/testdata/markdown/cache_already_empty.golden.md
@@ -1,0 +1,1 @@
+Cache at `/tmp/tflens-cache` was already empty.

--- a/pkg/render/testdata/markdown/cache_cleared_many.golden.md
+++ b/pkg/render/testdata/markdown/cache_cleared_many.golden.md
@@ -1,0 +1,1 @@
+Cleared 7 entries (1.0 MiB) from cache at `/tmp/tflens-cache`.

--- a/pkg/render/testdata/markdown/cache_cleared_one.golden.md
+++ b/pkg/render/testdata/markdown/cache_cleared_one.golden.md
@@ -1,0 +1,1 @@
+Cleared 1 entry (4.0 KiB) from cache at `/tmp/tflens-cache`.

--- a/pkg/render/testdata/markdown/cache_info_populated.golden.md
+++ b/pkg/render/testdata/markdown/cache_info_populated.golden.md
@@ -1,0 +1,5 @@
+## Cache info
+
+- **Path:** `/tmp/tflens-cache`
+- **Entries:** 42
+- **Size:** 5.5 MiB

--- a/pkg/render/testdata/markdown/cycles_clean.golden.md
+++ b/pkg/render/testdata/markdown/cycles_clean.golden.md
@@ -1,0 +1,3 @@
+## Dependency cycles
+
+**No cycles detected.** ✅

--- a/pkg/render/testdata/markdown/cycles_present.golden.md
+++ b/pkg/render/testdata/markdown/cycles_present.golden.md
@@ -1,0 +1,3 @@
+## Dependency cycles
+
+- `resource.aws_a.x` → `resource.aws_b.y` → `resource.aws_a.x`

--- a/pkg/render/testdata/markdown/deps_empty.golden.md
+++ b/pkg/render/testdata/markdown/deps_empty.golden.md
@@ -1,0 +1,9 @@
+## Dependencies of `resource.aws_vpc.main`
+
+**Depends on:**
+
+- _(none)_
+
+**Referenced by:**
+
+- _(none)_

--- a/pkg/render/testdata/markdown/deps_populated.golden.md
+++ b/pkg/render/testdata/markdown/deps_populated.golden.md
@@ -1,0 +1,10 @@
+## Dependencies of `resource.aws_vpc.main`
+
+**Depends on:**
+
+- `variable.cidr`
+
+**Referenced by:**
+
+- `resource.aws_subnet.a`
+- `resource.aws_subnet.b`

--- a/pkg/render/testdata/markdown/diff_changed_no_api_changes.golden.md
+++ b/pkg/render/testdata/markdown/diff_changed_no_api_changes.golden.md
@@ -1,0 +1,5 @@
+## `tflens diff` results
+
+_Base ref: `main` &middot; Path: `./infra`_
+
+**No changes detected vs `main`.** ✅

--- a/pkg/render/testdata/markdown/diff_mixed_changes.golden.md
+++ b/pkg/render/testdata/markdown/diff_mixed_changes.golden.md
@@ -1,0 +1,23 @@
+## `tflens diff` results
+
+_Base ref: `main` &middot; Path: `./infra`_
+
+**Summary:** 2 🔴 Breaking, 1 🟡 Non-breaking, 1 🔵 Informational
+
+## Root module
+
+- 🔴 Breaking &mdash; `variable.cluster_name`: required variable added
+  > **Fix:** add `cluster_name = ...` to the root invocation
+
+
+<details open><summary>Module <code>vpc</code> &mdash; version <code>1.0.0</code> → <code>2.0.0</code></summary>
+
+- 🔴 Breaking &mdash; `var.required`: removed
+  > **Fix:** callers passing this variable will fail
+- 🟡 Non-breaking &mdash; `var.tags`: added optional
+- 🔵 Informational &mdash; `out.docs`: description updated
+
+</details>
+
+### Module `eks` &mdash; **ADDED** (source `terraform-aws-modules/eks/aws`, version `20.0.0`)
+

--- a/pkg/render/testdata/markdown/diff_no_changes.golden.md
+++ b/pkg/render/testdata/markdown/diff_no_changes.golden.md
@@ -1,0 +1,5 @@
+## `tflens diff` results
+
+_Base ref: `main` &middot; Path: `./infra`_
+
+**No changes detected vs `main`.** ✅

--- a/pkg/render/testdata/markdown/diff_only_uninteresting_pair.golden.md
+++ b/pkg/render/testdata/markdown/diff_only_uninteresting_pair.golden.md
@@ -1,0 +1,5 @@
+## `tflens diff` results
+
+_Base ref: `main` &middot; Path: `./infra`_
+
+**No changes detected vs `main`.** ✅

--- a/pkg/render/testdata/markdown/diff_pair_removed.golden.md
+++ b/pkg/render/testdata/markdown/diff_pair_removed.golden.md
@@ -1,0 +1,5 @@
+## `tflens diff` results
+
+_Base ref: `main` &middot; Path: `./infra`_
+
+**No changes detected vs `main`.** ✅

--- a/pkg/render/testdata/markdown/fmt_parse_errors.golden.md
+++ b/pkg/render/testdata/markdown/fmt_parse_errors.golden.md
@@ -1,0 +1,4 @@
+## Parse errors
+
+- **Unexpected token**: Expected `}`, found `=` (`main.tf:12:5`)
+- **Generic error**: Something went wrong

--- a/pkg/render/testdata/markdown/impact_multiple.golden.md
+++ b/pkg/render/testdata/markdown/impact_multiple.golden.md
@@ -1,0 +1,6 @@
+## Impact of changing `variable.cidr`
+
+**2 entities affected** (topological order):
+
+1. `resource.aws_vpc.main`
+1. `resource.aws_subnet.a`

--- a/pkg/render/testdata/markdown/impact_none.golden.md
+++ b/pkg/render/testdata/markdown/impact_none.golden.md
@@ -1,0 +1,3 @@
+## Impact of changing `variable.unused`
+
+_No other entities affected._

--- a/pkg/render/testdata/markdown/impact_single.golden.md
+++ b/pkg/render/testdata/markdown/impact_single.golden.md
@@ -1,0 +1,5 @@
+## Impact of changing `variable.cidr`
+
+**1 entity affected** (topological order):
+
+1. `resource.aws_vpc.main`

--- a/pkg/render/testdata/markdown/inventory_empty.golden.md
+++ b/pkg/render/testdata/markdown/inventory_empty.golden.md
@@ -1,0 +1,3 @@
+## Inventory (0 entities)
+
+_(empty)_

--- a/pkg/render/testdata/markdown/inventory_populated.golden.md
+++ b/pkg/render/testdata/markdown/inventory_populated.golden.md
@@ -1,0 +1,6 @@
+## Inventory (2 entities)
+
+| Kind | ID | Location |
+| --- | --- | --- |
+| variable | `variable.x` | `test.tf:1` |
+| resource | `resource.aws_vpc.main` | `test.tf:2` |

--- a/pkg/render/testdata/markdown/statediff_clean.golden.md
+++ b/pkg/render/testdata/markdown/statediff_clean.golden.md
@@ -1,0 +1,3 @@
+## `tflens statediff` results
+
+**No flagged resources.** ✅

--- a/pkg/render/testdata/markdown/statediff_full.golden.md
+++ b/pkg/render/testdata/markdown/statediff_full.golden.md
@@ -1,0 +1,31 @@
+## `tflens statediff` results
+
+**3 flagged items.**
+
+### Added resources
+
+- `aws_s3_bucket.logs`
+
+### Removed resources
+
+- `aws_iam_user.old`
+
+### Renamed resources (via `moved` blocks)
+
+- `aws_vpc.main` → `aws_vpc.primary`
+
+### Sensitive changes reaching count/for_each
+
+<details><summary><code>local.regions</code> changed (`["us-east-1"]` → `["us-east-1","us-west-2"]`)</summary>
+
+Affected resources:
+
+- `aws_subnet.per_region` (via `for_each`)
+  - state instance: `aws_subnet.per_region["us-east-1"]`
+
+</details>
+
+### State orphans (in state but not in source)
+
+- `aws_security_group.legacy`
+

--- a/pkg/render/testdata/markdown/statediff_nil_result.golden.md
+++ b/pkg/render/testdata/markdown/statediff_nil_result.golden.md
@@ -1,0 +1,3 @@
+## `tflens statediff` results
+
+No state diff result.

--- a/pkg/render/testdata/markdown/statediff_sensitive_empty_values.golden.md
+++ b/pkg/render/testdata/markdown/statediff_sensitive_empty_values.golden.md
@@ -1,0 +1,10 @@
+## `tflens statediff` results
+
+**1 flagged item.**
+
+### Sensitive changes reaching count/for_each
+
+<details><summary><code>module.api.variable.absent_default</code> changed (`(absent)` → `(absent)`)</summary>
+
+</details>
+

--- a/pkg/render/testdata/markdown/unused_empty.golden.md
+++ b/pkg/render/testdata/markdown/unused_empty.golden.md
@@ -1,0 +1,3 @@
+## Unused entities (0)
+
+**No unused entities.** ✅

--- a/pkg/render/testdata/markdown/unused_populated.golden.md
+++ b/pkg/render/testdata/markdown/unused_populated.golden.md
@@ -1,0 +1,3 @@
+## Unused entities (1)
+
+- `local.dead_code` &mdash; `main.tf:5`

--- a/pkg/render/testdata/markdown/validate_clean.golden.md
+++ b/pkg/render/testdata/markdown/validate_clean.golden.md
@@ -1,0 +1,3 @@
+## `tflens validate` results
+
+**No issues found.** ✅

--- a/pkg/render/testdata/markdown/validate_mixed_errors.golden.md
+++ b/pkg/render/testdata/markdown/validate_mixed_errors.golden.md
@@ -1,0 +1,16 @@
+## `tflens validate` results
+
+**3 issues found.** 🔴
+
+### Undefined references
+
+- `resource.aws_vpc.main` references undeclared `var.typo` &mdash; `main.tf:12`
+
+### Cross-module issues
+
+- `module.vpc`: child requires `region` but root passes `regions` &mdash; `main.tf:5`
+
+### Type errors
+
+- `variable.count` (`default`): default value `"three"` is string, declared type number &mdash; `variables.tf:3`
+

--- a/pkg/render/testdata/markdown/validate_no_file_position.golden.md
+++ b/pkg/render/testdata/markdown/validate_no_file_position.golden.md
@@ -1,0 +1,8 @@
+## `tflens validate` results
+
+**1 issue found.** 🔴
+
+### Undefined references
+
+- `resource.aws_vpc.main` references undeclared `var.typo` &mdash; `:12`
+

--- a/pkg/render/testdata/markdown/validate_single_error.golden.md
+++ b/pkg/render/testdata/markdown/validate_single_error.golden.md
@@ -1,0 +1,8 @@
+## `tflens validate` results
+
+**1 issue found.** 🔴
+
+### Undefined references
+
+- `resource.aws_vpc.main` references undeclared `var.typo` &mdash; `main.tf:12`
+

--- a/pkg/render/testdata/markdown/whatif_clean_upgrade.golden.md
+++ b/pkg/render/testdata/markdown/whatif_clean_upgrade.golden.md
@@ -1,0 +1,8 @@
+## `tflens whatif` results
+
+_Base ref: `main` &middot; Path: `./infra`_
+
+### Module `vpc` &mdash; version `1.0.0` → `1.0.1`
+
+_(no consumer-affecting changes)_
+

--- a/pkg/render/testdata/markdown/whatif_direct_impact.golden.md
+++ b/pkg/render/testdata/markdown/whatif_direct_impact.golden.md
@@ -1,0 +1,18 @@
+## `tflens whatif` results
+
+_Base ref: `main` &middot; Path: `./infra`_
+
+**Summary:** 1 🔴 Breaking, 1 direct impact
+
+<details open><summary>🔴 Module `vpc` &mdash; version `1.0.0` → `2.0.0`</summary>
+
+**Direct impact on this caller:**
+
+- `module.vpc`: child no longer accepts argument
+
+**Full API diff:**
+
+- 🔴 Breaking &mdash; `var.removed_input`: removed
+
+</details>
+


### PR DESCRIPTION
## Summary

New global flag `--format markdown` emits a single GitHub-flavoured markdown document on stdout suitable for PR comments and step summaries:

```bash
tflens --format markdown diff --ref main ./infra | gh pr comment $PR --body-file -
tflens --format markdown statediff ./infra >> "$GITHUB_STEP_SUMMARY"
```

Like `--format json`, the whole document is single-stream (warnings stay on stdout) so it's pipeable.

## What it produces

**Rich treatment** for the four PR-relevant surfaces:

- **`diff`** — totals header (counts per severity), Root section + per-module sections inside `<details>`. Sections containing any 🔴 Breaking change get `open=open` so reviewers see the most important info immediately.
- **`whatif`** — same shape, plus a 🔴 prefix on direct-impact module headings, with the direct-impact errors listed before the full API diff inside the same details block.
- **`statediff`** — Added/Removed/Renamed sections, sensitive changes inside `<details>` with affected resources + state instances, state orphans listed.
- **`validate`** — Undefined refs / Cross-module / Type errors as separate subsections with file:line locations as inline backticks.

Severity badges: 🔴 Breaking / 🟡 Non-breaking / 🔵 Informational. Text label survives screen readers; emoji gives a quick visual scan.

**Terse impls** for the rest of the `Renderer` interface (`cycles`, `deps`, `impact`, `inventory`, `unused`, `cache *`, `fmt` parse errors) so the composite stays satisfied — they're rarely useful in PR comments but the contract is intact.

## Wiring

- `config.Settings` gains a `Markdown bool`, populated by `FromCommand` from `--format=markdown`
- `render.New(s)` switch dispatches Markdown → JSON → Console
- `cmd/fmt.go` and `cmd/validate.go`'s stdout/stderr split now accounts for both JSON and Markdown (both are single-stream modes)

## Test plan

- [x] `make check` — all packages pass
- [x] 8 table-driven golden cases under `pkg/render/testdata/markdown/<case>.golden.md` covering every primary surface (clean baseline + populated). Update with `go test ./pkg/render/... -run TestRendererMarkdownCases -update`.
- [x] Manual smoke test against `pkg/loader/testdata/manifest/no_manifest_local_sources_work` — the cross-module-issue path emits clean markdown with severity badges + inline location codes.