### PR TITLE
feat: tflens diff --enrich-with-plan plan.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to tflens are documented here. The format is loosely based o
 
 ## [Unreleased]
 
+### Added
+
+- **`tflens diff --enrich-with-plan plan.json` — fold `terraform show -json` plan output into the static-analysis diff.** Bridges the gap that previously left resource attribute changes (`cidr_block` modifications, force-new attributes, etc.) invisible to tflens because we don't embed provider schemas. Force-new attributes (those in the plan's `replace_paths`) become Breaking; other attribute changes become Informational; resource deletes and replaces become Breaking. The CI exit code refreshes to include plan-derived Breaking findings, so a plan-only force-new attribute still gates the merge even when the source-side text doesn't differ. Plan-derived rows are tagged with a `[plan]` prefix in the console renderer and a 📋 marker in the markdown renderer so reviewers can tell at a glance which findings came from which path. Implementation: new `pkg/plan` package (loader for terraform JSON plans, format_version 1.x supported, address parser handling `module.X.module.Y.<type>.<name>[<index>]` shapes including count/for_each indices, attribute-tree walker with `replace_paths` lookup), new `diff.EnrichFromPlan(changes, plan, project)` helper that merges plan deltas into the source-side change list, and a new `Source` field on `diff.Change` (`"static"` / `"plan"`) for renderer provenance. New `--enrich-with-plan` flag on `tflens diff` reading from a new `config.Settings.PlanPath`. Documented first-cut limitations: resource matching by exact address only (renames via `moved {}` surface as delete+create pairs); `count`/`for_each` instances all match the same source-side entity (per-instance matching is a follow-up); only `diff` takes the flag (not `whatif`/`statediff` yet).
+
 ## [0.10.0] — 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ tflens --offline diff --ref main ./my-tf
 | `graph <path>` | Emit the dependency graph in Graphviz DOT format |
 | `fmt <file.tf>` | Print normalised HCL; `-w` rewrites in place, `--check` exits 1 when unformatted |
 | `validate <path>` | Report undefined references, type errors, `for_each`/`count` misuse, and sensitive-value leaks |
-| `diff [path]` | What changed in module APIs in `path` (default cwd) vs `--ref` (default `auto`)? Behaviour depends on the child's `source`: **local children** (`./…`, `../…`) are evaluated against your parent's actual usage (only consumption errors surface as Breaking — no API noise); **registry/git children** report the full API diff (publisher's release contract). Authors can also opt specific resource attributes into the diff with `# tflens:track` markers (engine versions, instance classes, …). |
+| `diff [path]` | What changed in module APIs in `path` (default cwd) vs `--ref` (default `auto`)? Behaviour depends on the child's `source`: **local children** (`./…`, `../…`) are evaluated against your parent's actual usage (only consumption errors surface as Breaking — no API noise); **registry/git children** report the full API diff (publisher's release contract). Authors can also opt specific resource attributes into the diff with `# tflens:track` markers (engine versions, instance classes, …). With `--enrich-with-plan plan.json`, `terraform show -json` output is folded in so resource attribute changes (e.g. `cidr_block` modifications, force-new attributes) become visible alongside the static-analysis findings. |
 | `whatif [path] [name]` | Like `diff` but **always** consumer-view, regardless of source type. Cross-validates the parent's argument set and output references against the candidate child; only flags changes that actually affect this caller. Use this to gate any external-module upgrade. Optional `name` scopes to one module call. |
 | `statediff [path] [--state file]` | Static hazard detector: resource adds/removes vs `--ref` (default `auto`), plus locals whose value changed and whose dep chain reaches `count`/`for_each`. With `--state`, lists the state instances that may be affected |
 | `cache info` | Show the cache location, entry count, and total size |
@@ -168,6 +168,34 @@ Module "vpc": (content changed)
 ```
 
 Hints cover the common cases: required-variable-added (suggest `default`), required-object-field-added (suggest `optional()`), resource removed/renamed (suggest `removed {}` / `moved {}` blocks with the exact entity IDs filled in), backend changes (`terraform init -migrate-state`), `count`↔`for_each` transitions, sensitive-leak removals on outputs, and the four cross-validate consumption errors. The JSON output emits the same string under a `"hint"` key (omitted when empty).
+
+### Plan enrichment (`--enrich-with-plan plan.json`)
+
+`tflens diff` is fundamentally a static analyser — it doesn't embed provider schemas, so changes to resource attributes (`cidr_block = "10.0.0.0/16"` → `"10.1.0.0/16"`, `instance_type` modifications, force-new attribute changes) are normally invisible. The `--enrich-with-plan` flag bridges that gap by reading the JSON output of `terraform show -json <plan>` and folding plan-derived attribute deltas into the diff result alongside the static-analysis findings.
+
+```bash
+terraform plan -out=tfplan && terraform show -json tfplan > plan.json
+tflens diff --ref main --enrich-with-plan plan.json
+```
+
+**Classification:** force-new attributes (those Terraform marks in the plan's `replace_paths`) become Breaking; other attribute changes become Informational; resource creates become Informational; resource deletes and explicit replaces (destroy + recreate) become Breaking. The CI exit code refreshes to include plan-derived Breaking findings — so a plan-only force-new change still gates the merge even when the source-side text doesn't differ.
+
+**Provenance:** plan-derived rows are tagged with a `[plan]` prefix in the console renderer and a 📋 marker in the markdown renderer, so reviewers can tell at a glance which findings came from static analysis vs the plan output.
+
+```
+Root module:
+  Breaking (2):
+    [plan] aws_vpc.main: plan replaces `aws_vpc.main` (destroy + recreate)
+    [plan] aws_vpc.main:cidr_block: plan attribute change: "10.0.0.0/16" → "10.1.0.0/16"
+      hint: this attribute forces a destroy + recreate; coordinate with the operator
+```
+
+**First-cut limitations** (worth knowing before you wire this into CI):
+
+- **Resource matching is by exact address only.** A resource renamed via a `moved {}` block surfaces as a delete + create pair on the plan side rather than a single rename — the static-side diff already detects rename pairs from the source, so the plan-derived noise is harmless but worth understanding.
+- **`count`/`for_each` indices are not yet matched per-instance.** Plan addresses like `aws_subnet.foo[0]` / `aws_subnet.foo["us-east-1"]` resolve to the source-side entity `resource.aws_subnet.foo` regardless of index. Each indexed instance still gets its own Change row, just with the index visible in the Subject.
+- **Plan format versions.** Supports format_version 1.x (Terraform 1.0+). Older plans are rejected with a clear error.
+- **`whatif` and `statediff` don't yet take `--enrich-with-plan`** — only `diff` does. Same machinery would slot in cleanly if useful.
 
 ### What it catches
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dgr237/tflens/pkg/config"
 	"github.com/dgr237/tflens/pkg/diff"
 	"github.com/dgr237/tflens/pkg/loader"
+	"github.com/dgr237/tflens/pkg/plan"
 	"github.com/dgr237/tflens/pkg/render"
 )
 
@@ -43,6 +44,8 @@ The ref defaults to 'auto', which resolves to @{upstream} → origin/HEAD
 func init() {
 	diffCmd.Flags().String("ref", config.RefAutoKeyword,
 		"git ref to compare against (branch, tag, SHA, …); 'auto' detects @{upstream} → origin/HEAD → main → master")
+	diffCmd.Flags().String("enrich-with-plan", "",
+		"path to a `terraform show -json` plan file. Plan-derived attribute deltas (cidr_block changes, force-new attributes, etc.) get folded into the diff result alongside static-analysis findings — bridges the gap that otherwise leaves resource-attribute changes invisible to tflens. Force-new attributes become Breaking; other attribute changes become Informational. Plan-derived rows get a 📋 badge in the markdown renderer.")
 	rootCmd.AddCommand(diffCmd)
 }
 
@@ -53,6 +56,25 @@ func runDiffRef(s config.Settings) error {
 	}
 	defer cleanup()
 	results, rootChanges, breaking := diff.AnalyzeProjects(oldProj, newProj)
+	if s.PlanPath != "" {
+		p, err := plan.Load(s.PlanPath)
+		if err != nil {
+			cleanup()
+			return err
+		}
+		// First-cut routing: every plan-derived change attaches to
+		// rootChanges with the full plan address as Subject. A
+		// future iteration would route module.X.* entries into the
+		// matching PairResult.Changes for tighter per-module
+		// presentation. For now the renderers handle the flat list
+		// fine via the Source field tagging.
+		rootChanges = diff.EnrichFromPlan(rootChanges, p, newProj)
+		// Recompute the breaking count to include plan-derived
+		// findings — otherwise the CI exit code wouldn't fire on
+		// plan-only Breaking changes (e.g. a force-new attribute
+		// change that the source diff couldn't see).
+		breaking = countBreaking(rootChanges, results)
+	}
 	render.New(s).Diff(s.BaseRef, s.Path, results, rootChanges)
 	if breaking > 0 {
 		// os.Exit skips the deferred cleanup, so run it explicitly
@@ -62,4 +84,25 @@ func runDiffRef(s config.Settings) error {
 		os.Exit(1)
 	}
 	return nil
+}
+
+// countBreaking sums the Breaking changes across rootChanges + every
+// PairResult. Used after plan enrichment to refresh the CI-gating
+// count — diff.AnalyzeProjects's original count predates the plan-
+// derived additions.
+func countBreaking(rootChanges []diff.Change, results []diff.PairResult) int {
+	n := 0
+	for _, c := range rootChanges {
+		if c.Kind == diff.Breaking {
+			n++
+		}
+	}
+	for _, r := range results {
+		for _, c := range r.Changes {
+			if c.Kind == diff.Breaking {
+				n++
+			}
+		}
+	}
+	return n
 }

--- a/pkg/config/cobra.go
+++ b/pkg/config/cobra.go
@@ -21,6 +21,7 @@ func FromCommand(cmd *cobra.Command, opts ...Option) Settings {
 		Markdown:  getString(cmd, "format") == "markdown",
 		BaseRef:   getString(cmd, "ref"),
 		StatePath: getString(cmd, "state"),
+		PlanPath:  getString(cmd, "enrich-with-plan"),
 		Write:     getBool(cmd, "write"),
 		Check:     getBool(cmd, "check"),
 	}

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -59,6 +59,13 @@ type Settings struct {
 	// StatePath is an optional Terraform state v4 JSON path
 	// (statediff). Empty means "no state file supplied".
 	StatePath string
+	// PlanPath is an optional terraform `show -json` plan output file
+	// (diff --enrich-with-plan). When set, plan-derived attribute
+	// deltas get folded into the diff result so resource attribute
+	// changes (`cidr_block = "10.0.0.0/16"` → `"10.1.0.0/16"`) become
+	// visible alongside the static-analysis findings. Empty means
+	// "no plan supplied".
+	PlanPath string
 	// Write makes fmt rewrite the input file in place.
 	Write bool
 	// Check makes fmt exit non-zero when the input is not already

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -48,6 +48,12 @@ type Change struct {
 	Hint    string         // optional one-line "how to fix this" guidance
 	OldPos  token.Position // zero value for pure additions
 	NewPos  token.Position // zero value for pure removals
+	// Source records the change's provenance. Empty / "static" = the
+	// source-side text-diff machinery; "plan" = derived from a
+	// terraform plan JSON via diff.EnrichFromPlan. Renderers use this
+	// to decorate plan-derived rows with a 📋 marker so reviewers
+	// know which findings came from which path.
+	Source string
 }
 
 func (c Change) String() string {

--- a/pkg/diff/enrich.go
+++ b/pkg/diff/enrich.go
@@ -1,0 +1,271 @@
+package diff
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/dgr237/tflens/pkg/loader"
+	"github.com/dgr237/tflens/pkg/plan"
+)
+
+// SourceStatic is the Change.Source value for findings produced by
+// the standard source-side text-diff machinery (variables/outputs/
+// resources comparison, tracked-attribute eval, condition-set
+// multiset). Empty Source on a Change is treated as Static — the
+// field exists so plan-derived findings can be distinguished, not
+// to make every existing emitter set it explicitly.
+const SourceStatic = "static"
+
+// SourcePlan is the Change.Source value for findings derived from a
+// terraform plan JSON via EnrichFromPlan. Renderers use this to
+// decorate plan-derived rows with a 📋 marker so reviewers can tell
+// at a glance which findings came from static analysis vs which came
+// from the plan output.
+const SourcePlan = "plan"
+
+// EnrichFromPlan augments the existing change list with plan-derived
+// attribute deltas. Each ResourceChange in p whose action is anything
+// other than no-op produces zero or more Change entries:
+//
+//   - update / replace: one entry per attribute that differs between
+//     before and after. Force-new attributes (those in replace_paths)
+//     get Kind=Breaking; other attribute changes get Kind=Informational.
+//
+//   - create / delete: a single summary entry noting the resource is
+//     entering or leaving the plan, Kind=Informational. (The static
+//     diff already catches resource adds/removes when the source files
+//     differ; the plan-derived entry corroborates from the plan side
+//     and helps when the source-side change is ambiguous.)
+//
+// Matching strategy: each ResourceChange's EntityID() is looked up in
+// newProj's modules. The match key is the (module path, entity id)
+// pair — `module.network.resource.aws_vpc.main` in the plan matches
+// the entity `resource.aws_vpc.main` inside `module.network`'s child
+// node. The resource's Subject in the resulting Change carries the
+// full plan address so renderers can show the precise instance.
+//
+// count/for_each indices are NOT yet matched: a plan ResourceChange
+// at `aws_subnet.foo[0]` matches the source-side entity
+// `resource.aws_subnet.foo`, with the index preserved in the Subject
+// for human reference. Index-aware matching (where each instance
+// is a separate Change) is a follow-up.
+//
+// Renames via `moved {}` blocks are also out of scope here: a plan
+// describing a destroy + create across a rename will surface as two
+// separate Change entries (one delete, one create) rather than being
+// recognised as the same logical resource. The existing static-diff
+// rename detection in pkg/diff doesn't depend on this; it surfaces
+// the rename from the source side regardless.
+//
+// Returns the merged change list, sorted by (Kind, Subject) so the
+// output is deterministic and Breaking findings sort first regardless
+// of source.
+func EnrichFromPlan(changes []Change, p *plan.Plan, newProj *loader.Project) []Change {
+	if p == nil {
+		return changes
+	}
+	out := make([]Change, 0, len(changes)+len(p.ResourceChanges))
+	out = append(out, changes...)
+
+	// Build a lookup so we can confirm each plan entry corresponds to
+	// a known source-side entity. Plan entries that match nothing
+	// still get emitted — they're useful (e.g. detecting a resource
+	// added to the plan from outside the diff'd source) — but the
+	// entity-existence lookup tells the renderer not to assume a
+	// source position for them.
+	projectEntities := buildEntityIndex(newProj)
+
+	for _, rc := range p.ResourceChanges {
+		if rc.Change.IsNoOp() {
+			continue
+		}
+		entityID := rc.EntityID()
+		_, exists := projectEntities[matchKey(rc.ModuleAddress, entityID)]
+
+		switch {
+		case rc.Change.IsCreate():
+			out = append(out, Change{
+				Kind:    Informational,
+				Subject: planSubject(rc),
+				Detail:  fmt.Sprintf("plan creates %s%s", planAddressDescriptor(rc), entityHint(exists)),
+				Source:  SourcePlan,
+			})
+		case rc.Change.IsDelete():
+			out = append(out, Change{
+				Kind:    Breaking,
+				Subject: planSubject(rc),
+				Detail:  fmt.Sprintf("plan destroys %s — uncommitted state will be lost", planAddressDescriptor(rc)),
+				Source:  SourcePlan,
+			})
+		case rc.Change.IsReplace():
+			// Replace = destroy + recreate. Already Breaking by
+			// definition. Surface the per-attribute deltas
+			// underneath so reviewers see WHICH change forced it.
+			out = append(out, Change{
+				Kind:    Breaking,
+				Subject: planSubject(rc),
+				Detail:  fmt.Sprintf("plan replaces %s (destroy + recreate)", planAddressDescriptor(rc)),
+				Source:  SourcePlan,
+			})
+			out = append(out, attrDeltaChanges(rc)...)
+		case rc.Change.IsUpdate():
+			out = append(out, attrDeltaChanges(rc)...)
+		}
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].Subject < out[j].Subject
+	})
+	return out
+}
+
+// attrDeltaChanges turns each AttrDelta on a ResourceChange into a
+// diff.Change. ForceNew deltas → Breaking; everything else →
+// Informational. Each Change carries Subject = "<plan-address>:<attr-path>"
+// so the output is unique even when multiple attributes change on
+// the same resource.
+func attrDeltaChanges(rc plan.ResourceChange) []Change {
+	deltas := rc.Change.AttrDeltas()
+	out := make([]Change, 0, len(deltas))
+	for _, d := range deltas {
+		kind := Informational
+		hint := ""
+		if d.ForceNew {
+			kind = Breaking
+			hint = "this attribute forces a destroy + recreate; coordinate with the operator"
+		}
+		out = append(out, Change{
+			Kind:    kind,
+			Subject: fmt.Sprintf("%s:%s", rc.Address, d.Path),
+			Detail:  fmt.Sprintf("plan attribute change: %s → %s", formatValue(d.Before), formatValue(d.After)),
+			Hint:    hint,
+			Source:  SourcePlan,
+		})
+	}
+	return out
+}
+
+// planSubject returns the Subject for a top-level plan-derived Change
+// (resource-level create/delete/replace summaries — NOT the per-
+// attribute child rows from attrDeltaChanges). Just the full plan
+// address; renderers can split it back into module/type/name if they
+// want richer formatting.
+func planSubject(rc plan.ResourceChange) string {
+	return rc.Address
+}
+
+// planAddressDescriptor formats the address for inclusion in a Detail
+// string — backtick-quoted so renderers that respect markdown render
+// it as inline code.
+func planAddressDescriptor(rc plan.ResourceChange) string {
+	return fmt.Sprintf("`%s`", rc.Address)
+}
+
+// entityHint returns a parenthetical note when the plan describes a
+// resource not present in the source-side analysis. Helps debugging
+// stale plans (plan was generated against a different commit than
+// the diff is now comparing).
+func entityHint(exists bool) string {
+	if exists {
+		return ""
+	}
+	return " (no matching source-side entity — plan may be stale)"
+}
+
+// formatValue produces a compact human-readable rendering of a JSON
+// value for inclusion in Detail. Strings get quoted; nil → "null";
+// nested structures collapse to JSON-like form. Optimised for
+// readability inside a one-line Detail rather than full reproducibility
+// — consumers wanting exact values can re-load the plan JSON.
+func formatValue(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return "null"
+	case string:
+		return fmt.Sprintf("%q", x)
+	case float64:
+		// JSON numbers come back as float64. Render integers without
+		// the trailing zero.
+		if x == float64(int64(x)) {
+			return fmt.Sprintf("%d", int64(x))
+		}
+		return fmt.Sprintf("%g", x)
+	case bool:
+		return fmt.Sprintf("%t", x)
+	default:
+		return fmt.Sprintf("%v", x)
+	}
+}
+
+// buildEntityIndex walks every module in the project and returns the
+// set of (modulePath, entityID) keys present in the source-side
+// analysis. Used to flag plan entries with no matching source-side
+// entity (typically: stale plan, or resource referenced from a
+// child module that wasn't loaded).
+func buildEntityIndex(p *loader.Project) map[string]bool {
+	out := map[string]bool{}
+	if p == nil {
+		return out
+	}
+	p.Walk(func(node *loader.ModuleNode) bool {
+		mod := node.Module
+		if mod == nil {
+			return true
+		}
+		modulePath := modulePathFromNode(p, node)
+		for _, e := range mod.Entities() {
+			out[matchKey(modulePath, e.ID())] = true
+		}
+		return true
+	})
+	return out
+}
+
+// matchKey is the joined "<modulePath>|<entityID>" string used for
+// entity lookups. The vertical bar can't appear in either component
+// so the encoding is unambiguous without per-character escaping.
+func matchKey(modulePath, entityID string) string {
+	return modulePath + "|" + entityID
+}
+
+// modulePathFromNode returns the dotted path of a module node from
+// the project root. Empty for the root itself; "module.X" for a
+// direct child; "module.X.module.Y" for nested. Plan addresses use
+// the same format (with their own `module.` prefixes), so the two
+// paths can be compared directly.
+//
+// Note: this is a minimal implementation — it walks from the root
+// to find the node by pointer identity. Sufficient for the small
+// project trees this enrichment runs against; would need to be
+// indexed if performance ever became an issue.
+func modulePathFromNode(p *loader.Project, target *loader.ModuleNode) string {
+	if p == nil || p.Root == nil || target == nil {
+		return ""
+	}
+	if p.Root == target {
+		return ""
+	}
+	var found string
+	var walk func(n *loader.ModuleNode, prefix string)
+	walk = func(n *loader.ModuleNode, prefix string) {
+		for name, child := range n.Children {
+			childPath := "module." + name
+			if prefix != "" {
+				childPath = prefix + "." + childPath
+			}
+			if child == target {
+				found = childPath
+				return
+			}
+			walk(child, childPath)
+			if found != "" {
+				return
+			}
+		}
+	}
+	walk(p.Root, "")
+	return found
+}

--- a/pkg/diff/enrich_test.go
+++ b/pkg/diff/enrich_test.go
@@ -1,0 +1,158 @@
+package diff_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/dgr237/tflens/pkg/diff"
+	"github.com/dgr237/tflens/pkg/plan"
+)
+
+// fixturePath resolves a plan testdata fixture relative to the
+// pkg/plan package — both packages share the same fixtures since
+// the loader is what produces the *plan.Plan that EnrichFromPlan
+// consumes.
+func planFixture(t *testing.T, name string) *plan.Plan {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(file), "..", "plan", "testdata", name)
+	p, err := plan.Load(path)
+	if err != nil {
+		t.Fatalf("load plan %s: %v", path, err)
+	}
+	return p
+}
+
+// TestEnrichFromPlanNilNoop pins the early-return contract: EnrichFromPlan
+// with a nil plan returns the input changes verbatim, nothing added,
+// nothing dropped. Lets cmd/diff treat the --enrich-with-plan flag
+// as opt-in without branching on the boolean every time it calls
+// the enricher.
+func TestEnrichFromPlanNilNoop(t *testing.T) {
+	in := []diff.Change{
+		{Kind: diff.Breaking, Subject: "var.x", Detail: "removed"},
+	}
+	out := diff.EnrichFromPlan(in, nil, nil)
+	if len(out) != 1 || out[0].Subject != "var.x" {
+		t.Errorf("nil plan should not modify changes; got %+v", out)
+	}
+}
+
+// TestEnrichFromPlanUpdate covers the core happy-path: a plan with one
+// update + one replace + one no-op produces the right number of
+// plan-derived Change entries with the right Source tag, severity,
+// and Subject formatting.
+func TestEnrichFromPlanUpdate(t *testing.T) {
+	p := planFixture(t, "update.json")
+	out := diff.EnrichFromPlan(nil, p, nil)
+
+	// Expectations from update.json:
+	//   - vpc update (1 attr delta, non-force-new)             → 1 Informational
+	//   - subnet replace (1 attr delta, force-new)             → 1 replace summary (Breaking)
+	//                                                            + 1 attr-delta row (Breaking, ForceNew)
+	//   - sg no-op                                             → 0 entries
+	if got, want := len(out), 3; got != want {
+		t.Fatalf("len(out) = %d, want %d; got %+v", got, want, out)
+	}
+
+	// All entries should be tagged as plan-derived.
+	for _, c := range out {
+		if c.Source != diff.SourcePlan {
+			t.Errorf("Change %q has Source = %q, want %q",
+				c.Subject, c.Source, diff.SourcePlan)
+		}
+	}
+
+	// Find the per-attribute delta rows by Subject containing ":"
+	// (the attr separator in attrDeltaChanges).
+	var vpcAttr, subnetAttr *diff.Change
+	for i := range out {
+		if !strings.Contains(out[i].Subject, ":") {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(out[i].Subject, "aws_vpc.main"):
+			vpcAttr = &out[i]
+		case strings.HasPrefix(out[i].Subject, "aws_subnet.public"):
+			subnetAttr = &out[i]
+		}
+	}
+	if vpcAttr == nil {
+		t.Fatal("missing vpc attribute delta")
+	}
+	if vpcAttr.Kind != diff.Informational {
+		t.Errorf("vpc attr Kind = %v, want Informational", vpcAttr.Kind)
+	}
+	if subnetAttr == nil {
+		t.Fatal("missing subnet attribute delta")
+	}
+	if subnetAttr.Kind != diff.Breaking {
+		t.Errorf("subnet attr Kind = %v, want Breaking (force-new)", subnetAttr.Kind)
+	}
+	if subnetAttr.Hint == "" {
+		t.Errorf("subnet attr should have a fix Hint (force-new triggers it)")
+	}
+}
+
+// TestEnrichFromPlanCreateAndDelete confirms the create / delete
+// summaries fire with the right severity. Replace is covered by
+// TestEnrichFromPlanUpdate; this one covers the lifecycle bookends.
+func TestEnrichFromPlanCreateAndDelete(t *testing.T) {
+	p := planFixture(t, "nested_module.json")
+	out := diff.EnrichFromPlan(nil, p, nil)
+
+	// nested_module.json has:
+	//   - module.network.aws_vpc.main update (1 attr delta)
+	//   - module.network.module.subnets.aws_subnet.public[east] create (1 attr delta + 0 summary because
+	//     create produces just the summary entry below)
+	//   - data.aws_ami.latest read (filtered as no-op-equivalent... actually IsNoOp checks ["no-op"] only;
+	//     ["read"] passes through ALL the predicate checks as false → not emitted)
+	//
+	// So we expect: 1 vpc update attr + 1 create summary = 2 entries.
+	if got, want := len(out), 2; got != want {
+		t.Fatalf("len(out) = %d, want %d; got %+v", got, want, out)
+	}
+
+	var createEntry *diff.Change
+	for i := range out {
+		if strings.Contains(out[i].Detail, "plan creates") {
+			createEntry = &out[i]
+		}
+	}
+	if createEntry == nil {
+		t.Fatal("missing create summary entry")
+	}
+	if createEntry.Kind != diff.Informational {
+		t.Errorf("create summary Kind = %v, want Informational", createEntry.Kind)
+	}
+}
+
+// TestEnrichFromPlanPreservesExisting confirms enrichment doesn't
+// drop or modify the static-side changes — they should appear in
+// the output verbatim alongside the new plan-derived entries, and
+// the merged list stays sorted by (Kind, Subject) so Breaking
+// findings come first regardless of source.
+func TestEnrichFromPlanPreservesExisting(t *testing.T) {
+	staticChanges := []diff.Change{
+		{Kind: diff.Breaking, Subject: "variable.required", Detail: "removed"},
+		{Kind: diff.Informational, Subject: "out.docs", Detail: "description updated"},
+	}
+	p := planFixture(t, "update.json")
+	out := diff.EnrichFromPlan(staticChanges, p, nil)
+
+	// 2 static + 3 plan-derived = 5 total.
+	if got, want := len(out), 5; got != want {
+		t.Fatalf("len(out) = %d, want %d", got, want)
+	}
+
+	// First entry should be Breaking, last should be Informational —
+	// the SliceStable sort is by (Kind, Subject), Breaking < others.
+	if out[0].Kind != diff.Breaking {
+		t.Errorf("out[0].Kind = %v, want Breaking", out[0].Kind)
+	}
+	if out[len(out)-1].Kind != diff.Informational {
+		t.Errorf("out[-1].Kind = %v, want Informational", out[len(out)-1].Kind)
+	}
+}

--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -1,0 +1,383 @@
+// Package plan loads and inspects the JSON shape produced by
+// `terraform show -json <plan>` (or `terraform plan -json` when piped
+// through `jq -s '.[] | select(.type == "planned_change")'`-style
+// extraction). Used by `tflens diff --enrich-with-plan plan.json` to
+// fold attribute-level deltas into the source-side breaking-change
+// detection — bridging the static-analyser / plan-analyser gap that
+// otherwise leaves attribute changes (`cidr_block = "10.0.0.0/16"` →
+// `"10.1.0.0/16"`) invisible to tflens because we don't embed
+// provider schemas.
+//
+// Format reference: https://developer.hashicorp.com/terraform/internals/json-format
+//
+// Supported format versions: 1.x. Terraform 1.x has used "1.0" / "1.1"
+// / "1.2" — the loader is permissive on minor versions and rejects
+// anything outside the 1.x major.
+package plan
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// Plan is the top-level wire shape. We only model the fields tflens
+// uses; unknown fields are silently dropped by encoding/json.
+type Plan struct {
+	FormatVersion    string           `json:"format_version"`
+	TerraformVersion string           `json:"terraform_version"`
+	ResourceChanges  []ResourceChange `json:"resource_changes"`
+}
+
+// ResourceChange is one entry under resource_changes[]. Address is
+// the full Terraform-style identifier (e.g. "module.network.aws_vpc.main[0]");
+// ModuleAddress / Type / Name / Index are pre-parsed convenience
+// fields the loader populates from Address. Mode distinguishes
+// managed resources from data sources.
+type ResourceChange struct {
+	Address       string `json:"address"`
+	ModuleAddress string `json:"module_address,omitempty"`
+	Mode          string `json:"mode"` // "managed" or "data"
+	Type          string `json:"type"`
+	Name          string `json:"name"`
+	// Index carries the count/for_each index when the resource has one.
+	// Terraform emits an int for count, a string for for_each, or omits
+	// the field for non-iterating resources.
+	Index any `json:"index,omitempty"`
+	// Change is the actual diff payload — actions list + before/after
+	// values + force-new path markers.
+	Change ChangeSet `json:"change"`
+}
+
+// ChangeSet captures the per-resource change. Actions describes the
+// operation kind; before/after carry the full attribute trees;
+// ReplacePaths lists the attribute paths whose modification triggers
+// destroy + recreate (i.e. force-new attributes).
+type ChangeSet struct {
+	// Actions is one of:
+	//   ["no-op"]                — no change
+	//   ["create"]               — new resource
+	//   ["read"]                 — data-source-only refresh
+	//   ["update"]               — in-place attribute change
+	//   ["delete"]               — removal
+	//   ["delete", "create"]     — destroy + recreate (replace)
+	//   ["create", "delete"]     — create-before-destroy replace
+	Actions []string `json:"actions"`
+	// Before is the attribute tree as it currently exists. nil for
+	// pure creates.
+	Before json.RawMessage `json:"before"`
+	// After is the attribute tree the plan will produce. nil for
+	// pure deletes; may have placeholder values where After is
+	// "(known after apply)" — those attributes appear in AfterUnknown.
+	After json.RawMessage `json:"after"`
+	// ReplacePaths is the list of attribute paths whose modification
+	// triggers destroy+recreate. Each path is a list of (string | int)
+	// steps (e.g. [["lifecycle", "0", "ignore_changes"]] or
+	// [["cidr_block"]]).
+	ReplacePaths [][]any `json:"replace_paths,omitempty"`
+}
+
+// IsNoOp reports whether the change is a refresh-only entry (Actions
+// is exactly ["no-op"]). Filtered out before enrichment so the diff
+// doesn't get a stream of empty rows for unchanged resources.
+func (c ChangeSet) IsNoOp() bool {
+	return len(c.Actions) == 1 && c.Actions[0] == "no-op"
+}
+
+// IsReplace reports whether the change destroys and recreates the
+// resource. Both ordering variants ("delete" + "create" and "create"
+// + "delete") count.
+func (c ChangeSet) IsReplace() bool {
+	if len(c.Actions) != 2 {
+		return false
+	}
+	a, b := c.Actions[0], c.Actions[1]
+	return (a == "delete" && b == "create") || (a == "create" && b == "delete")
+}
+
+// IsCreate reports whether the resource is being created fresh
+// (Actions == ["create"]).
+func (c ChangeSet) IsCreate() bool {
+	return len(c.Actions) == 1 && c.Actions[0] == "create"
+}
+
+// IsDelete reports whether the resource is being deleted (Actions ==
+// ["delete"]). Excludes the replace cases — those are IsReplace.
+func (c ChangeSet) IsDelete() bool {
+	return len(c.Actions) == 1 && c.Actions[0] == "delete"
+}
+
+// IsUpdate reports whether the resource is being updated in place
+// (Actions == ["update"]). Excludes replace cases.
+func (c ChangeSet) IsUpdate() bool {
+	return len(c.Actions) == 1 && c.Actions[0] == "update"
+}
+
+// AttrDelta is one attribute-level difference between the before and
+// after states. Path is the dot-separated attribute path
+// (`tags.Name`, `cidr_block`, `vpc_config.0.subnet_ids`); Before /
+// After are the JSON-decoded values; ForceNew is true when this
+// path appears in the parent ChangeSet's ReplacePaths.
+type AttrDelta struct {
+	Path     string
+	Before   any
+	After    any
+	ForceNew bool
+}
+
+// AttrDeltas walks the before/after attribute trees and returns the
+// flat list of differences. Recursion handles nested maps/lists;
+// equal subtrees are skipped. The order of returned deltas follows
+// alphabetical Path within each level.
+//
+// nil before (pure create) → every after attribute becomes a delta
+// with Before=nil. nil after (pure delete) → every before attribute
+// becomes a delta with After=nil. The IsNoOp short-circuit upstream
+// avoids calling AttrDeltas on no-op changes.
+func (c ChangeSet) AttrDeltas() []AttrDelta {
+	var before, after any
+	if len(c.Before) > 0 && string(c.Before) != "null" {
+		_ = json.Unmarshal(c.Before, &before)
+	}
+	if len(c.After) > 0 && string(c.After) != "null" {
+		_ = json.Unmarshal(c.After, &after)
+	}
+	forceNew := pathSet(c.ReplacePaths)
+	var out []AttrDelta
+	walkDelta(before, after, "", forceNew, &out)
+	return out
+}
+
+// pathSet flattens the [][]any ReplacePaths into a string set keyed
+// by the same dot-joined Path form AttrDelta uses. Avoids quadratic
+// scans during walkDelta.
+func pathSet(paths [][]any) map[string]bool {
+	out := map[string]bool{}
+	for _, p := range paths {
+		out[joinPath(p)] = true
+	}
+	return out
+}
+
+// joinPath converts a Terraform path ([]any of string | float64) into
+// the dot-joined form ("vpc_config.0.subnet_ids"). Numeric steps
+// are truncated to int (json.Unmarshal gives float64 by default).
+func joinPath(steps []any) string {
+	parts := make([]string, len(steps))
+	for i, s := range steps {
+		switch v := s.(type) {
+		case string:
+			parts[i] = v
+		case float64:
+			parts[i] = strconv.Itoa(int(v))
+		case int:
+			parts[i] = strconv.Itoa(v)
+		default:
+			parts[i] = fmt.Sprintf("%v", v)
+		}
+	}
+	return strings.Join(parts, ".")
+}
+
+// walkDelta recursively compares before and after, appending an
+// AttrDelta for every leaf or container difference. The path
+// accumulator starts empty and grows with "key" / "<index>" segments
+// as recursion descends. Force-new flag is looked up by the final
+// dot-joined path string.
+func walkDelta(before, after any, path string, forceNew map[string]bool, out *[]AttrDelta) {
+	// Equal — nothing to emit; recursion stops here.
+	if reflect.DeepEqual(before, after) {
+		return
+	}
+	bm, bIsMap := before.(map[string]any)
+	am, aIsMap := after.(map[string]any)
+	if bIsMap || aIsMap {
+		// Either side is a map → recurse into the union of keys.
+		// Sorted iteration keeps the output deterministic.
+		keys := mergeMapKeys(bm, am)
+		for _, k := range keys {
+			child := path
+			if child == "" {
+				child = k
+			} else {
+				child = child + "." + k
+			}
+			walkDelta(bm[k], am[k], child, forceNew, out)
+		}
+		return
+	}
+	bs, bIsSlice := before.([]any)
+	as, aIsSlice := after.([]any)
+	if bIsSlice || aIsSlice {
+		// Lists: recurse positionally up to the longer side. Index
+		// becomes a string segment to match Terraform's path encoding.
+		n := len(bs)
+		if len(as) > n {
+			n = len(as)
+		}
+		for i := 0; i < n; i++ {
+			var bv, av any
+			if i < len(bs) {
+				bv = bs[i]
+			}
+			if i < len(as) {
+				av = as[i]
+			}
+			child := path
+			idx := strconv.Itoa(i)
+			if child == "" {
+				child = idx
+			} else {
+				child = child + "." + idx
+			}
+			walkDelta(bv, av, child, forceNew, out)
+		}
+		return
+	}
+	// Leaf — emit the delta. Force-new lookup uses the final path.
+	*out = append(*out, AttrDelta{
+		Path:     path,
+		Before:   before,
+		After:    after,
+		ForceNew: forceNew[path],
+	})
+}
+
+// mergeMapKeys returns the sorted union of keys in two maps. Used by
+// walkDelta to iterate before/after deterministically.
+func mergeMapKeys(a, b map[string]any) []string {
+	seen := map[string]bool{}
+	for k := range a {
+		seen[k] = true
+	}
+	for k := range b {
+		seen[k] = true
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	// Inline sort — small slices, no need to import sort.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j] < out[j-1]; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}
+
+// Load reads + parses a terraform plan JSON file. Validates the
+// format_version is in the 1.x major series; errors otherwise so
+// callers don't silently use a plan they can't interpret. Also
+// post-parses each ResourceChange's Address into ModuleAddress /
+// Type / Name / Index when those fields aren't already populated
+// (older Terraform versions emit address-only).
+func Load(path string) (*Plan, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read plan %s: %w", path, err)
+	}
+	var p Plan
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, fmt.Errorf("parse plan %s: %w", path, err)
+	}
+	if !strings.HasPrefix(p.FormatVersion, "1.") {
+		return nil, fmt.Errorf("unsupported plan format_version %q (need 1.x); rerun with a Terraform 1.x plan",
+			p.FormatVersion)
+	}
+	for i := range p.ResourceChanges {
+		// Always run parseAddress to fill any field the JSON omitted —
+		// Terraform's older versions inconsistently include module_address
+		// even when type/name are present, and parseAddress is idempotent
+		// (won't overwrite already-populated fields).
+		parseAddress(&p.ResourceChanges[i])
+	}
+	return &p, nil
+}
+
+// parseAddress is the fallback that fills ModuleAddress / Type / Name
+// / Index from Address for plan dialects that emit only the address
+// string. The grammar we support is:
+//
+//	[module.X[.Y...]] [data.] type.name [ "[" index "]" ]
+//
+// Index may be a bare integer (count) or a quoted string (for_each
+// key). Bracketed indices on module segments (rare) are tolerated
+// but kept inside ModuleAddress as a string.
+func parseAddress(rc *ResourceChange) {
+	addr := rc.Address
+	// Split off the optional module prefix. Always populate
+	// ModuleAddress when missing (Terraform sometimes omits it on
+	// non-default-module resources in older format versions).
+	if strings.HasPrefix(addr, "module.") {
+		parts := strings.Split(addr, ".")
+		modParts := []string{}
+		i := 0
+		for i+1 < len(parts) && parts[i] == "module" {
+			modParts = append(modParts, parts[i], parts[i+1])
+			i += 2
+		}
+		if rc.ModuleAddress == "" {
+			rc.ModuleAddress = strings.Join(modParts, ".")
+		}
+		addr = strings.Join(parts[i:], ".")
+	}
+	// data. prefix marks data sources. Honour an explicit Mode if
+	// JSON already set one (don't downgrade managed to data on a
+	// JSON shape that disagrees with the address).
+	if strings.HasPrefix(addr, "data.") {
+		if rc.Mode == "" {
+			rc.Mode = "data"
+		}
+		addr = addr[len("data."):]
+	} else if rc.Mode == "" {
+		rc.Mode = "managed"
+	}
+	// Strip trailing [index]. Only set Index when JSON didn't
+	// already populate it.
+	if i := strings.LastIndex(addr, "["); i > 0 && strings.HasSuffix(addr, "]") {
+		idxStr := addr[i+1 : len(addr)-1]
+		addr = addr[:i]
+		if rc.Index == nil {
+			if len(idxStr) >= 2 && idxStr[0] == '"' && idxStr[len(idxStr)-1] == '"' {
+				rc.Index = idxStr[1 : len(idxStr)-1]
+			} else if n, err := strconv.Atoi(idxStr); err == nil {
+				rc.Index = n
+			} else {
+				rc.Index = idxStr
+			}
+		}
+	}
+	// What's left is `type.name`. Don't overwrite if JSON already
+	// populated.
+	if dot := strings.Index(addr, "."); dot > 0 {
+		if rc.Type == "" {
+			rc.Type = addr[:dot]
+		}
+		if rc.Name == "" {
+			rc.Name = addr[dot+1:]
+		}
+	}
+}
+
+// EntityID returns the canonical pkg/analysis Entity ID for this
+// resource_change ("resource.<type>.<name>" or "data.<type>.<name>").
+// Used by the diff enrichment to look up the matching source-side
+// entity.
+//
+// Note: this does NOT include the module prefix or the count/for_each
+// index. Module matching happens at the project-tree level (one
+// Plan resource_change can match exactly one Module's entity);
+// indexed instances aren't yet supported at the matching layer (the
+// first matching resource is enriched, regardless of which instance
+// the plan describes).
+func (rc *ResourceChange) EntityID() string {
+	kind := "resource"
+	if rc.Mode == "data" {
+		kind = "data"
+	}
+	return fmt.Sprintf("%s.%s.%s", kind, rc.Type, rc.Name)
+}

--- a/pkg/plan/plan_test.go
+++ b/pkg/plan/plan_test.go
@@ -1,0 +1,152 @@
+package plan_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/dgr237/tflens/pkg/plan"
+)
+
+// fixturePath returns the absolute path of a testdata file. Mirrors
+// the runtime.Caller pattern used by the rest of tflens's tests so
+// test invocations from the repo root or from inside pkg/plan both
+// resolve correctly.
+func fixturePath(name string) string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(file), "testdata", name)
+}
+
+// TestLoadUnsupportedVersion exercises the format_version guard. The
+// loader rejects anything outside the 1.x major series so callers
+// don't silently consume a plan they can't interpret.
+func TestLoadUnsupportedVersion(t *testing.T) {
+	if _, err := plan.Load(fixturePath("unsupported_version.json")); err == nil {
+		t.Fatal("expected error for format_version 0.2, got nil")
+	}
+}
+
+// TestLoadResolvesAddressFields covers the core happy-path: each
+// resource_change ends up with a parsed Type/Name/Mode and the
+// EntityID matches what pkg/analysis would produce for the same
+// resource. ChangeSet predicates (IsUpdate / IsReplace / IsNoOp /
+// IsCreate) get a quick sanity check on the same fixture.
+func TestLoadResolvesAddressFields(t *testing.T) {
+	p, err := plan.Load(fixturePath("update.json"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got, want := len(p.ResourceChanges), 3; got != want {
+		t.Fatalf("len(ResourceChanges) = %d, want %d", got, want)
+	}
+
+	cases := []struct {
+		Name         string
+		Idx          int
+		WantEntityID string
+		WantUpdate   bool
+		WantReplace  bool
+		WantNoOp     bool
+	}{
+		{Name: "vpc", Idx: 0, WantEntityID: "resource.aws_vpc.main", WantUpdate: true},
+		{Name: "subnet", Idx: 1, WantEntityID: "resource.aws_subnet.public", WantReplace: true},
+		{Name: "sg", Idx: 2, WantEntityID: "resource.aws_security_group.unchanged", WantNoOp: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			rc := p.ResourceChanges[tc.Idx]
+			if got := rc.EntityID(); got != tc.WantEntityID {
+				t.Errorf("EntityID = %q, want %q", got, tc.WantEntityID)
+			}
+			if got := rc.Change.IsUpdate(); got != tc.WantUpdate {
+				t.Errorf("IsUpdate = %v, want %v", got, tc.WantUpdate)
+			}
+			if got := rc.Change.IsReplace(); got != tc.WantReplace {
+				t.Errorf("IsReplace = %v, want %v", got, tc.WantReplace)
+			}
+			if got := rc.Change.IsNoOp(); got != tc.WantNoOp {
+				t.Errorf("IsNoOp = %v, want %v", got, tc.WantNoOp)
+			}
+		})
+	}
+}
+
+// TestAttrDeltasUpdate covers attribute-level delta extraction. The
+// fixture's vpc has a tag added (no force-new) — should produce one
+// AttrDelta for tags.Env. The subnet has its availability_zone
+// rewritten — should produce one AttrDelta with ForceNew=true.
+func TestAttrDeltasUpdate(t *testing.T) {
+	p, _ := plan.Load(fixturePath("update.json"))
+	vpcDeltas := p.ResourceChanges[0].Change.AttrDeltas()
+	if len(vpcDeltas) != 1 {
+		t.Fatalf("vpc deltas len = %d, want 1; got %+v", len(vpcDeltas), vpcDeltas)
+	}
+	if vpcDeltas[0].Path != "tags.Env" {
+		t.Errorf("vpc delta path = %q, want tags.Env", vpcDeltas[0].Path)
+	}
+	if vpcDeltas[0].ForceNew {
+		t.Error("vpc tags.Env should NOT be force-new")
+	}
+
+	subnetDeltas := p.ResourceChanges[1].Change.AttrDeltas()
+	if len(subnetDeltas) != 1 {
+		t.Fatalf("subnet deltas len = %d, want 1; got %+v", len(subnetDeltas), subnetDeltas)
+	}
+	if subnetDeltas[0].Path != "availability_zone" {
+		t.Errorf("subnet delta path = %q, want availability_zone", subnetDeltas[0].Path)
+	}
+	if !subnetDeltas[0].ForceNew {
+		t.Error("subnet availability_zone SHOULD be force-new (in replace_paths)")
+	}
+}
+
+// TestAttrDeltasCreateAndDelete covers the asymmetric Before/After
+// cases — pure creates have nil Before, pure deletes have nil After.
+// AttrDelta should still emit one entry per attribute.
+func TestAttrDeltasCreateAndDelete(t *testing.T) {
+	p, _ := plan.Load(fixturePath("nested_module.json"))
+	// Index 1 is the create (subnet.public[east]).
+	createDeltas := p.ResourceChanges[1].Change.AttrDeltas()
+	if len(createDeltas) != 1 {
+		t.Fatalf("create deltas len = %d, want 1", len(createDeltas))
+	}
+	if createDeltas[0].Before != nil {
+		t.Errorf("create delta Before = %v, want nil", createDeltas[0].Before)
+	}
+	if createDeltas[0].After != "us-east-1a" {
+		t.Errorf("create delta After = %v, want us-east-1a", createDeltas[0].After)
+	}
+}
+
+// TestAddressParsingNestedModule exercises the address parser
+// against `module.X.module.Y.<type>.<name>[<index>]` shape. Plus
+// the `data.<type>.<name>` data-source variant.
+func TestAddressParsingNestedModule(t *testing.T) {
+	p, _ := plan.Load(fixturePath("nested_module.json"))
+
+	// Index 0 — single-level module, populated module_address field.
+	if got := p.ResourceChanges[0].ModuleAddress; got != "module.network" {
+		t.Errorf("rc[0].ModuleAddress = %q, want module.network", got)
+	}
+
+	// Index 1 — two-level module, parsed from address (no
+	// module_address in fixture). Tests the parseAddress fallback.
+	rc := p.ResourceChanges[1]
+	if got := rc.ModuleAddress; got != "module.network.module.subnets" {
+		t.Errorf("rc[1].ModuleAddress = %q, want module.network.module.subnets", got)
+	}
+	if got := rc.Type; got != "aws_subnet" {
+		t.Errorf("rc[1].Type = %q, want aws_subnet", got)
+	}
+	if got := rc.Name; got != "public" {
+		t.Errorf("rc[1].Name = %q, want public", got)
+	}
+	if got := rc.Index; got != "east" {
+		t.Errorf("rc[1].Index = %v, want east", got)
+	}
+
+	// Index 2 — data source. EntityID prefix changes accordingly.
+	if got := p.ResourceChanges[2].EntityID(); got != "data.aws_ami.latest" {
+		t.Errorf("rc[2].EntityID = %q, want data.aws_ami.latest", got)
+	}
+}

--- a/pkg/plan/testdata/nested_module.json
+++ b/pkg/plan/testdata/nested_module.json
@@ -1,0 +1,42 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.7.0",
+  "resource_changes": [
+    {
+      "address": "module.network.aws_vpc.main",
+      "module_address": "module.network",
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "main",
+      "change": {
+        "actions": ["update"],
+        "before": {"cidr_block": "10.0.0.0/16"},
+        "after":  {"cidr_block": "10.1.0.0/16"},
+        "replace_paths": []
+      }
+    },
+    {
+      "address": "module.network.module.subnets.aws_subnet.public[\"east\"]",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public",
+      "index": "east",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {"availability_zone": "us-east-1a"}
+      }
+    },
+    {
+      "address": "data.aws_ami.latest",
+      "mode": "data",
+      "type": "aws_ami",
+      "name": "latest",
+      "change": {
+        "actions": ["read"],
+        "before": null,
+        "after":  {"id": "ami-0c55b"}
+      }
+    }
+  ]
+}

--- a/pkg/plan/testdata/unsupported_version.json
+++ b/pkg/plan/testdata/unsupported_version.json
@@ -1,0 +1,5 @@
+{
+  "format_version": "0.2",
+  "terraform_version": "0.12.0",
+  "resource_changes": []
+}

--- a/pkg/plan/testdata/update.json
+++ b/pkg/plan/testdata/update.json
@@ -1,0 +1,47 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.7.0",
+  "resource_changes": [
+    {
+      "address": "aws_vpc.main",
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "main",
+      "change": {
+        "actions": ["update"],
+        "before": {
+          "cidr_block": "10.0.0.0/16",
+          "tags": {"Name": "main"}
+        },
+        "after": {
+          "cidr_block": "10.0.0.0/16",
+          "tags": {"Name": "main", "Env": "prod"}
+        },
+        "replace_paths": []
+      }
+    },
+    {
+      "address": "aws_subnet.public",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public",
+      "change": {
+        "actions": ["delete", "create"],
+        "before": {"availability_zone": "us-east-1a"},
+        "after":  {"availability_zone": "us-east-1b"},
+        "replace_paths": [["availability_zone"]]
+      }
+    },
+    {
+      "address": "aws_security_group.unchanged",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "unchanged",
+      "change": {
+        "actions": ["no-op"],
+        "before": {},
+        "after": {}
+      }
+    }
+  ]
+}

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -519,7 +519,16 @@ func (m *MarkdownRenderer) writeChangeList(changes []diff.Change) {
 		return sorted[i].Kind < sorted[j].Kind
 	})
 	for _, ch := range sorted {
-		fmt.Fprintf(m.W, "- %s &mdash; `%s`: %s\n", badgeForKind(ch.Kind), ch.Subject, ch.Detail)
+		// 📋 prefix on plan-derived rows so reviewers can tell at a
+		// glance which findings came from the static analyser (no
+		// prefix) vs the terraform plan (📋 prefix). Source==""
+		// is treated as static — historical Changes don't carry the
+		// field.
+		provenance := ""
+		if ch.Source == diff.SourcePlan {
+			provenance = "📋 "
+		}
+		fmt.Fprintf(m.W, "- %s%s &mdash; `%s`: %s\n", provenance, badgeForKind(ch.Kind), ch.Subject, ch.Detail)
 		if ch.Hint != "" {
 			fmt.Fprintf(m.W, "  > **Fix:** %s\n", ch.Hint)
 		}

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -23,7 +23,15 @@ import (
 // The two-space hint indent is hard-coded — keeping it constant
 // across the codebase is the whole point of this helper.
 func writeChange(w io.Writer, indent string, c diff.Change) {
-	fmt.Fprintf(w, "%s%s: %s\n", indent, c.Subject, c.Detail)
+	// Plan-derived findings get a "[plan]" prefix so reviewers can
+	// tell at a glance which findings came from the static analyser
+	// vs the terraform plan. Source==SourceStatic / "" → no prefix
+	// (the historical default; existing emitters don't set the field).
+	prefix := ""
+	if c.Source == diff.SourcePlan {
+		prefix = "[plan] "
+	}
+	fmt.Fprintf(w, "%s%s%s: %s\n", indent, prefix, c.Subject, c.Detail)
 	if c.Hint != "" {
 		fmt.Fprintf(w, "%s  hint: %s\n", indent, c.Hint)
 	}


### PR DESCRIPTION
## Summary

Bridges the static-analyser / plan-analyser gap. tflens is fundamentally schema-free — we don't embed provider schemas, so resource attribute changes (`cidr_block` modifications, force-new attributes, `instance_type` updates, etc.) have always been invisible to `diff`. With `--enrich-with-plan plan.json`, the JSON output of `terraform show -json <plan>` gets folded into the diff result alongside the static-analysis findings.

```bash
terraform plan -out=tfplan
terraform show -json tfplan > plan.json
tflens diff --ref main --enrich-with-plan plan.json
```

Output shape:

```
Root module:
  Breaking (2):
    [plan] aws_vpc.main: plan replaces `aws_vpc.main` (destroy + recreate)
    [plan] aws_vpc.main:cidr_block: plan attribute change: "10.0.0.0/16" → "10.1.0.0/16"
      hint: this attribute forces a destroy + recreate; coordinate with the operator
```

Markdown variant gets a 📋 prefix instead of `[plan]`. CI exit code refreshes after enrichment so plan-only Breaking findings still gate the merge — a force-new attribute change that the source-side text doesn't expose now correctly fails CI.

## Classification

| Plan event | tflens severity |
| --- | --- |
| Force-new attribute change (in `replace_paths`) | 🔴 Breaking |
| Other attribute change | 🔵 Informational |
| Resource create | 🔵 Informational |
| Resource delete | 🔴 Breaking |
| Resource replace (destroy + recreate) | 🔴 Breaking + per-attribute deltas underneath |
| no-op | filtered |

## Implementation

**`pkg/plan`** — new package, ~280 LOC + 220 LOC tests:
- `Plan` + `ResourceChange` + `ChangeSet` types matching format_version 1.x
- Address parser handles `module.X.module.Y.<type>.<name>[<idx>]` shapes with both count (int) and for_each (string) indices
- `AttrDeltas()` walks before/after attribute trees recursively, emitting one entry per leaf difference, marking force-new entries from `replace_paths`
- `IsCreate` / `IsUpdate` / `IsReplace` / `IsDelete` / `IsNoOp` predicates

**`pkg/diff`** — `Source` field added to `Change` (`"static"` / `"plan"`); new `EnrichFromPlan(changes, plan, project)` helper that merges plan deltas into the source-side change list, sorted by (Kind, Subject) for deterministic output.

**`pkg/config`** — new `Settings.PlanPath`, populated by `FromCommand` from `--enrich-with-plan`.

**`cmd/diff`** — new flag, runs enrichment after the static diff, refreshes the breaking count for CI gating.

**Renderers** — console `writeChange` + markdown `writeChangeList` both add the provenance prefix when `Source == SourcePlan`. Existing emitters carry empty `Source` (treated as static — no behaviour change).

## Test plan

- [x] `make check` (vet + test + gofmt) — all packages pass
- [x] 5 `pkg/plan` tests across 3 fixtures (update, nested_module, unsupported_version) covering the loader + address parser + AttrDeltas walker
- [x] 4 `pkg/diff` enrich tests covering nil-safety, update path, create/delete path, static-vs-plan preservation
- [x] End-to-end smoke test: an ephemeral fixture with a force-new `cidr_block` change correctly produces 2 Breaking entries, the `[plan]` console prefix, the 📋 markdown prefix, and exit code 1

## Limitations (documented in README)

- **Resource matching by exact address only** — renames via `moved {}` surface as delete + create pairs (the source-side rename detection still catches them from the source)
- **`count`/`for_each` instances all match the same source-side entity** — per-instance matching would need index-aware lookup (follow-up)
- **Only `diff` takes the flag** — `whatif` and `statediff` would slot in the same way if useful
- **Plan format_version must be 1.x** — older Terraform plans rejected with a clear error