### PR TITLE
plan enrichment: sensitive redaction, known-after-apply, per-module routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to tflens are documented here. The format is loosely based o
 
 ## [Unreleased]
 
+### Added
+
+- **`tflens diff --enrich-with-plan` — sensitive value redaction.** Plan attributes flagged via `before_sensitive` / `after_sensitive` (anything that flowed through a sensitive variable, sensitive output, or `sensitive = true` resource attribute) now render as `(sensitive)` instead of the raw value. Without this fix, a plan touching e.g. an RDS password would write the password into CI logs the moment a reviewer ran `tflens diff --enrich-with-plan` against the PR. New `BeforeSensitive`/`AfterSensitive` fields on `pkg/plan.AttrDelta`; `pkg/plan` walker drills the sensitive-shadow trees in parallel with the data so per-leaf flags are exact even when the shadow has structured content. Subtree-wide sensitive markers (the entire structured value is sensitive — e.g. an `aws_secretsmanager_secret_version.secret_string` map) emit a single `(sensitive)` row at the subtree level rather than descending into placeholder children. `pkg/diff/enrich.go`'s renderer substitutes the marker before the value reaches Detail, so no renderer downstream can accidentally leak it.
+
+- **`tflens diff --enrich-with-plan` — `(known after apply)` rendering.** Plan attributes whose post-apply value is computed by the provider (flagged via the plan's `after_unknown` shadow) now render as `(known after apply)` instead of `<nil>`. Previously a `null`-valued After looked indistinguishable from "the attribute is being unset", which misled reviewers reading enrichment output for resources with provider-computed fields (`arn`, `id`, etc.). New `AfterUnknown` field on `pkg/plan.AttrDelta`; the walker emits a delta for unknown leaves even when before/after compare equal (both are placeholder nulls until apply fills the value in).
+
+- **`tflens diff --enrich-with-plan` — per-module routing of plan-derived findings.** Plan-derived rows whose module address matches a paired module call now land under that pair's section in the rendered output instead of all collapsing into the project-root section. Previously reviewers had to mentally join the static-side findings for `module.network` with the plan-side findings for the same module that were sitting in a separate root-level block. New `diff.EnrichResultsFromPlan(results, rootChanges, plan, project)` entry point routes each plan ResourceChange by converting its `module_address` (`module.X.module.Y`, with count/for_each indices stripped) to the dotted-key form `loader.ModuleCallPair` uses (`X.Y`); unmatched module addresses fall through to rootChanges so a stale plan referencing a missing module is still visible. `cmd/diff.go` swapped to the new helper. Existing flat `EnrichFromPlan` retained as a thin wrapper around the now-shared `changesForResourceChange` helper for callers that don't have a results slice.
+
 ## [0.11.1] — 2026-04-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ tflens diff --ref main --enrich-with-plan plan.json
 
 **Provenance:** plan-derived rows are tagged with a `[plan]` prefix in the console renderer and a 📋 marker in the markdown renderer, so reviewers can tell at a glance which findings came from static analysis vs the plan output.
 
+**Sensitive value redaction.** Attributes flagged via the plan's `before_sensitive` / `after_sensitive` shadow trees (anything that flowed through a sensitive variable, sensitive output, or `sensitive = true` resource attribute) render as `(sensitive)` instead of the raw value. Subtree-wide markers (e.g. an entire `aws_secretsmanager_secret_version.secret_string` map flagged sensitive) collapse to a single `(sensitive)` row at the subtree level rather than descending into placeholder children. This is enforced inside `pkg/diff/enrich.go` before the value reaches Detail — no renderer downstream can accidentally leak it.
+
+**`(known after apply)` rendering.** Attributes whose post-apply value is computed by the provider (the plan's `after_unknown` shadow) render as `(known after apply)` rather than `<nil>`, so `aws_db_instance.main:arn` showing `→ (known after apply)` is unambiguously "the provider will fill this in" rather than "the attribute is being unset".
+
+**Per-module routing.** Plan-derived rows whose module address matches a paired module call land under that pair's section in the rendered output, next to the static-side findings for the same module. Plan rows for unmatched modules (or for the root) accumulate in the project-root section. Indexed module addresses (`module.regions["us-east-1"]`) route to the underlying `module.regions` pair regardless of how many instances the for_each / count produces.
+
 ```
 Root module:
   Breaking (2):

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -62,13 +62,11 @@ func runDiffRef(s config.Settings) error {
 			cleanup()
 			return err
 		}
-		// First-cut routing: every plan-derived change attaches to
-		// rootChanges with the full plan address as Subject. A
-		// future iteration would route module.X.* entries into the
-		// matching PairResult.Changes for tighter per-module
-		// presentation. For now the renderers handle the flat list
-		// fine via the Source field tagging.
-		rootChanges = diff.EnrichFromPlan(rootChanges, p, newProj)
+		// Per-module routing: plan-derived changes whose module
+		// address matches a paired call land under that pair's
+		// section in the rendered output; unmatched (or root-module)
+		// findings fall back to rootChanges.
+		results, rootChanges = diff.EnrichResultsFromPlan(results, rootChanges, p, newProj)
 		// Recompute the breaking count to include plan-derived
 		// findings — otherwise the CI exit code wouldn't fire on
 		// plan-only Breaking changes (e.g. a force-new attribute

--- a/pkg/diff/enrich.go
+++ b/pkg/diff/enrich.go
@@ -80,55 +80,174 @@ func EnrichFromPlan(changes []Change, p *plan.Plan, newProj *loader.Project) []C
 		if rc.Change.IsNoOp() {
 			continue
 		}
-		entityID := rc.EntityID()
-		// Strip count/for_each indices from each module segment when
-		// looking up the source-side entity — the source-side module
-		// tree has one node per module CALL, not per instance, so
-		// `module.foo[0].aws_vpc.main` and `module.foo[1].aws_vpc.main`
-		// both need to find the same `module.foo`. Resource indices
-		// (the trailing `[idx]` on the resource itself) are already
-		// stripped by EntityID(), which goes through the entity's
-		// canonical ID without index decoration.
-		_, exists := projectEntities[matchKey(stripIndices(rc.ModuleAddress), entityID)]
-
-		switch {
-		case rc.Change.IsCreate():
-			out = append(out, Change{
-				Kind:    Informational,
-				Subject: planSubject(rc),
-				Detail:  fmt.Sprintf("plan creates %s%s", planAddressDescriptor(rc), entityHint(exists)),
-				Source:  SourcePlan,
-			})
-		case rc.Change.IsDelete():
-			out = append(out, Change{
-				Kind:    Breaking,
-				Subject: planSubject(rc),
-				Detail:  fmt.Sprintf("plan destroys %s — uncommitted state will be lost", planAddressDescriptor(rc)),
-				Source:  SourcePlan,
-			})
-		case rc.Change.IsReplace():
-			// Replace = destroy + recreate. Already Breaking by
-			// definition. Surface the per-attribute deltas
-			// underneath so reviewers see WHICH change forced it.
-			out = append(out, Change{
-				Kind:    Breaking,
-				Subject: planSubject(rc),
-				Detail:  fmt.Sprintf("plan replaces %s (destroy + recreate)", planAddressDescriptor(rc)),
-				Source:  SourcePlan,
-			})
-			out = append(out, attrDeltaChanges(rc)...)
-		case rc.Change.IsUpdate():
-			out = append(out, attrDeltaChanges(rc)...)
-		}
+		out = append(out, changesForResourceChange(rc, lookupEntity(projectEntities, rc))...)
 	}
 
-	sort.SliceStable(out, func(i, j int) bool {
-		if out[i].Kind != out[j].Kind {
-			return out[i].Kind < out[j].Kind
-		}
-		return out[i].Subject < out[j].Subject
-	})
+	sortChanges(out)
 	return out
+}
+
+// EnrichResultsFromPlan is the per-module-aware variant of
+// EnrichFromPlan. Findings whose module_address matches a paired
+// module call land in that PairResult.Changes; findings for the
+// root module (or for a module that doesn't have a paired call —
+// typically a module added or removed entirely between sides) fall
+// back to rootChanges.
+//
+// The motivation: with the flat EnrichFromPlan, a plan describing
+// a `cidr_block` change inside `module.network` shows up under the
+// project root in the rendered output, even though the source-side
+// findings for `module.network` already have their own per-pair
+// section. Reviewers had to mentally join the two. This routing
+// puts plan-derived rows next to the matching static-side rows.
+//
+// Each result's Changes gets re-sorted after enrichment so the
+// merged (static, plan) rows interleave by (Kind, Subject) — the
+// same ordering AnalyzeProjects produces for the original list.
+//
+// Returns the (possibly modified) results slice + the merged
+// rootChanges. The results slice is mutated in place; callers that
+// need the originals untouched should clone first.
+func EnrichResultsFromPlan(results []PairResult, rootChanges []Change,
+	p *plan.Plan, newProj *loader.Project) ([]PairResult, []Change) {
+	if p == nil {
+		return results, rootChanges
+	}
+	// Pair key → results index. Empty-key entries (root pairs, if any
+	// ever existed) skip routing — root-module findings always go
+	// through rootChanges.
+	pairIdx := map[string]int{}
+	for i, r := range results {
+		if r.Pair.Key != "" {
+			pairIdx[r.Pair.Key] = i
+		}
+	}
+	projectEntities := buildEntityIndex(newProj)
+	mergedRoot := append([]Change(nil), rootChanges...)
+
+	for _, rc := range p.ResourceChanges {
+		if rc.Change.IsNoOp() {
+			continue
+		}
+		rcChanges := changesForResourceChange(rc, lookupEntity(projectEntities, rc))
+		if len(rcChanges) == 0 {
+			continue
+		}
+		key := planModuleKey(rc.ModuleAddress)
+		if i, ok := pairIdx[key]; ok {
+			results[i].Changes = append(results[i].Changes, rcChanges...)
+			continue
+		}
+		mergedRoot = append(mergedRoot, rcChanges...)
+	}
+
+	for i := range results {
+		sortChanges(results[i].Changes)
+	}
+	sortChanges(mergedRoot)
+	return results, mergedRoot
+}
+
+// changesForResourceChange returns the plan-derived Change entries for
+// one ResourceChange. Centralised so EnrichFromPlan and the per-
+// module routing variant produce identical Detail / Kind / Subject
+// shapes — the only difference between the two callers is which
+// bucket the result lands in.
+//
+// `exists` is the precomputed entity-index lookup result so callers
+// don't repeat the work; it controls the "no matching source-side
+// entity" hint on create entries.
+func changesForResourceChange(rc plan.ResourceChange, exists bool) []Change {
+	var out []Change
+	switch {
+	case rc.Change.IsCreate():
+		out = append(out, Change{
+			Kind:    Informational,
+			Subject: planSubject(rc),
+			Detail:  fmt.Sprintf("plan creates %s%s", planAddressDescriptor(rc), entityHint(exists)),
+			Source:  SourcePlan,
+		})
+	case rc.Change.IsDelete():
+		out = append(out, Change{
+			Kind:    Breaking,
+			Subject: planSubject(rc),
+			Detail:  fmt.Sprintf("plan destroys %s — uncommitted state will be lost", planAddressDescriptor(rc)),
+			Source:  SourcePlan,
+		})
+	case rc.Change.IsReplace():
+		// Replace = destroy + recreate. Already Breaking by
+		// definition. Surface the per-attribute deltas underneath so
+		// reviewers see WHICH change forced it.
+		out = append(out, Change{
+			Kind:    Breaking,
+			Subject: planSubject(rc),
+			Detail:  fmt.Sprintf("plan replaces %s (destroy + recreate)", planAddressDescriptor(rc)),
+			Source:  SourcePlan,
+		})
+		out = append(out, attrDeltaChanges(rc)...)
+	case rc.Change.IsUpdate():
+		out = append(out, attrDeltaChanges(rc)...)
+	}
+	return out
+}
+
+// lookupEntity hides the index-stripping detail so both enrichment
+// entry points share a single way to ask "does this plan's resource
+// match a known source-side entity?".
+func lookupEntity(index map[string]bool, rc plan.ResourceChange) bool {
+	// Strip count/for_each indices from each module segment when
+	// looking up the source-side entity — the source-side module tree
+	// has one node per module CALL, not per instance, so
+	// `module.foo[0].aws_vpc.main` and `module.foo[1].aws_vpc.main`
+	// both need to find the same `module.foo`. Resource indices on
+	// the trailing `[idx]` are already stripped by EntityID(), which
+	// goes through the entity's canonical ID without index decoration.
+	return index[matchKey(stripIndices(rc.ModuleAddress), rc.EntityID())]
+}
+
+// sortChanges orders a slice by (Kind, Subject) so Breaking findings
+// come first and ties break alphabetically. SliceStable preserves
+// insertion order within a (Kind, Subject) tie — useful when a single
+// resource emits a summary row + per-attribute rows that share the
+// same Subject prefix.
+func sortChanges(s []Change) {
+	sort.SliceStable(s, func(i, j int) bool {
+		if s[i].Kind != s[j].Kind {
+			return s[i].Kind < s[j].Kind
+		}
+		return s[i].Subject < s[j].Subject
+	})
+}
+
+// planModuleKey converts a plan's module_address (e.g.
+// `module.regions["us-east-1"].module.subnets`) into the dotted-key
+// form loader.ModuleCallPair uses (`regions.subnets`). Returns "" for
+// an empty input (root module).
+//
+// count/for_each indices are stripped first so multiple instances of
+// the same module call route to the same pair — there's only ever one
+// PairResult per call regardless of how many instances it expands to.
+//
+// If the input doesn't fit the `module.X.module.Y...` shape (e.g. a
+// malformed address), returns "" so the caller falls back to root
+// rather than risk routing to a wrong pair.
+func planModuleKey(moduleAddress string) string {
+	stripped := stripIndices(moduleAddress)
+	if stripped == "" {
+		return ""
+	}
+	parts := strings.Split(stripped, ".")
+	if len(parts)%2 != 0 {
+		return ""
+	}
+	keyParts := make([]string, 0, len(parts)/2)
+	for i := 0; i < len(parts); i += 2 {
+		if parts[i] != "module" {
+			return ""
+		}
+		keyParts = append(keyParts, parts[i+1])
+	}
+	return strings.Join(keyParts, ".")
 }
 
 // attrDeltaChanges turns each AttrDelta on a ResourceChange into a
@@ -136,6 +255,12 @@ func EnrichFromPlan(changes []Change, p *plan.Plan, newProj *loader.Project) []C
 // Informational. Each Change carries Subject = "<plan-address>:<attr-path>"
 // so the output is unique even when multiple attributes change on
 // the same resource.
+//
+// Sensitive markers redact the rendered value before it lands in
+// Detail — without this, a `tflens diff --enrich-with-plan` against
+// a plan touching e.g. an RDS password would write the password into
+// CI logs. AfterUnknown surfaces as "(known after apply)" so the
+// reader can tell a placeholder apart from an unset attribute.
 func attrDeltaChanges(rc plan.ResourceChange) []Change {
 	deltas := rc.Change.AttrDeltas()
 	out := make([]Change, 0, len(deltas))
@@ -149,12 +274,35 @@ func attrDeltaChanges(rc plan.ResourceChange) []Change {
 		out = append(out, Change{
 			Kind:    kind,
 			Subject: fmt.Sprintf("%s:%s", rc.Address, d.Path),
-			Detail:  fmt.Sprintf("plan attribute change: %s → %s", formatValue(d.Before), formatValue(d.After)),
+			Detail:  fmt.Sprintf("plan attribute change: %s → %s", renderBefore(d), renderAfter(d)),
 			Hint:    hint,
 			Source:  SourcePlan,
 		})
 	}
 	return out
+}
+
+// renderBefore formats the AttrDelta's Before value for inclusion in
+// Detail. Sensitive markers take precedence — we never want the raw
+// value in the output even if a renderer is being permissive.
+func renderBefore(d plan.AttrDelta) string {
+	if d.BeforeSensitive {
+		return "(sensitive)"
+	}
+	return formatValue(d.Before)
+}
+
+// renderAfter formats the AttrDelta's After value for inclusion in
+// Detail. Unknown beats sensitive (the value isn't computed yet, so
+// "sensitive" would be misleading); both beat the raw value.
+func renderAfter(d plan.AttrDelta) string {
+	switch {
+	case d.AfterUnknown:
+		return "(known after apply)"
+	case d.AfterSensitive:
+		return "(sensitive)"
+	}
+	return formatValue(d.After)
 }
 
 // planSubject returns the Subject for a top-level plan-derived Change

--- a/pkg/diff/enrich_test.go
+++ b/pkg/diff/enrich_test.go
@@ -221,6 +221,157 @@ resource "aws_vpc" "main" {}
 	}
 }
 
+// TestEnrichResultsFromPlanRoutesByModule pins the per-module routing.
+// The fixture has:
+//   - module.network.aws_vpc.main update     → routes to PairResult{Key: "network"}
+//   - module.network.module.subnets.aws_subnet.public[east] create
+//     → routes to PairResult{Key: "network.subnets"}
+//   - data.aws_ami.latest read               → filtered (no-op-equivalent)
+//
+// We pre-stage two empty PairResults with matching keys; the routing
+// should land each plan-derived row inside the right one without
+// touching rootChanges.
+func TestEnrichResultsFromPlanRoutesByModule(t *testing.T) {
+	results := []diff.PairResult{
+		{Pair: loader.ModuleCallPair{Key: "network", LocalName: "network"}},
+		{Pair: loader.ModuleCallPair{Key: "network.subnets", LocalName: "subnets"}},
+	}
+	rootChanges := []diff.Change{
+		{Kind: diff.Informational, Subject: "out.docs", Detail: "static-side root finding", Source: diff.SourceStatic},
+	}
+
+	p := planFixture(t, "nested_module.json")
+	gotResults, gotRoot := diff.EnrichResultsFromPlan(results, rootChanges, p, nil)
+
+	// rootChanges should still contain only the original static-side
+	// finding — every plan row had a matching pair so nothing
+	// fell through.
+	if len(gotRoot) != 1 || gotRoot[0].Subject != "out.docs" {
+		t.Errorf("rootChanges should be unchanged; got %+v", gotRoot)
+	}
+	// `network` pair should have one update row (vpc.cidr_block).
+	if got := len(gotResults[0].Changes); got != 1 {
+		t.Fatalf("network pair Changes len = %d, want 1; got %+v", got, gotResults[0].Changes)
+	}
+	if !strings.HasPrefix(gotResults[0].Changes[0].Subject, "module.network.aws_vpc.main") {
+		t.Errorf("network pair routed wrong row: %q", gotResults[0].Changes[0].Subject)
+	}
+	// `network.subnets` pair should have one create summary.
+	if got := len(gotResults[1].Changes); got != 1 {
+		t.Fatalf("subnets pair Changes len = %d, want 1; got %+v", got, gotResults[1].Changes)
+	}
+	if !strings.Contains(gotResults[1].Changes[0].Detail, "plan creates") {
+		t.Errorf("subnets pair routed wrong row: %+v", gotResults[1].Changes[0])
+	}
+}
+
+// TestEnrichResultsFromPlanFallsBackToRoot covers the case where a
+// plan describes a module not in the pair list — typically a stale
+// plan or a module that doesn't appear in the diff. Those rows should
+// land in rootChanges with the full plan address as Subject so
+// reviewers can still see them.
+func TestEnrichResultsFromPlanFallsBackToRoot(t *testing.T) {
+	// No paired module calls — every plan row will fall through to root.
+	var results []diff.PairResult
+	p := planFixture(t, "nested_module.json")
+	gotResults, gotRoot := diff.EnrichResultsFromPlan(results, nil, p, nil)
+
+	if len(gotResults) != 0 {
+		t.Errorf("results should remain empty; got %+v", gotResults)
+	}
+	// nested_module.json has 2 non-no-op changes (vpc update + subnet
+	// create) → 1 + 1 = 2 plan-derived entries in rootChanges.
+	if got, want := len(gotRoot), 2; got != want {
+		t.Fatalf("rootChanges len = %d, want %d; got %+v", got, want, gotRoot)
+	}
+	for _, c := range gotRoot {
+		if c.Source != diff.SourcePlan {
+			t.Errorf("rootChanges entry %q should be Source=plan; got %q", c.Subject, c.Source)
+		}
+	}
+}
+
+// TestEnrichResultsFromPlanNilNoop pins the early-return contract:
+// passing nil plan returns the inputs verbatim so cmd/diff doesn't
+// have to branch on the --enrich-with-plan flag at every call site.
+func TestEnrichResultsFromPlanNilNoop(t *testing.T) {
+	results := []diff.PairResult{
+		{Pair: loader.ModuleCallPair{Key: "x"}, Changes: []diff.Change{{Subject: "x"}}},
+	}
+	rootChanges := []diff.Change{{Subject: "y"}}
+	gotResults, gotRoot := diff.EnrichResultsFromPlan(results, rootChanges, nil, nil)
+	if len(gotResults) != 1 || gotResults[0].Pair.Key != "x" {
+		t.Errorf("nil plan should leave results unchanged; got %+v", gotResults)
+	}
+	if len(gotRoot) != 1 || gotRoot[0].Subject != "y" {
+		t.Errorf("nil plan should leave rootChanges unchanged; got %+v", gotRoot)
+	}
+}
+
+// TestEnrichFromPlanRedactsSensitiveAndUnknown pins the renderer
+// substitution behaviour: a plan touching a sensitive attribute
+// must NOT spill the value into the Detail (it would land in CI
+// logs), and a `(known after apply)` attribute must show that text
+// instead of `<nil>` (which looks like the attribute is being unset).
+func TestEnrichFromPlanRedactsSensitiveAndUnknown(t *testing.T) {
+	p := planFixture(t, "sensitive_and_unknown.json")
+	out := diff.EnrichFromPlan(nil, p, nil)
+
+	// Find the password and arn rows for the RDS resource.
+	var passwordEntry, arnEntry, engineEntry, secretEntry *diff.Change
+	for i := range out {
+		switch out[i].Subject {
+		case "aws_db_instance.main:password":
+			passwordEntry = &out[i]
+		case "aws_db_instance.main:arn":
+			arnEntry = &out[i]
+		case "aws_db_instance.main:engine_version":
+			engineEntry = &out[i]
+		case "aws_secretsmanager_secret_version.config:secret_string":
+			secretEntry = &out[i]
+		}
+	}
+
+	if passwordEntry == nil {
+		t.Fatal("missing password entry")
+	}
+	if strings.Contains(passwordEntry.Detail, "hunter2") ||
+		strings.Contains(passwordEntry.Detail, "correcthorsebatterystaple") {
+		t.Errorf("password Detail leaked the value: %q", passwordEntry.Detail)
+	}
+	if !strings.Contains(passwordEntry.Detail, "(sensitive)") {
+		t.Errorf("password Detail should contain (sensitive); got %q", passwordEntry.Detail)
+	}
+
+	if arnEntry == nil {
+		t.Fatal("missing arn entry")
+	}
+	if !strings.Contains(arnEntry.Detail, "(known after apply)") {
+		t.Errorf("arn Detail should contain (known after apply); got %q", arnEntry.Detail)
+	}
+
+	if engineEntry == nil {
+		t.Fatal("missing engine_version entry")
+	}
+	if !strings.Contains(engineEntry.Detail, "14.5") || !strings.Contains(engineEntry.Detail, "15.1") {
+		t.Errorf("engine_version Detail should contain raw values; got %q", engineEntry.Detail)
+	}
+
+	if secretEntry == nil {
+		t.Fatal("missing secret_string entry — should emit ONE subtree-level delta, not per-leaf rows")
+	}
+	if strings.Contains(secretEntry.Detail, "db_pass") ||
+		strings.Contains(secretEntry.Detail, "api_key") {
+		t.Errorf("secret subtree leaked inner keys: %q", secretEntry.Detail)
+	}
+	// And no per-leaf rows for the inner keys leaked through.
+	for _, c := range out {
+		if strings.HasPrefix(c.Subject, "aws_secretsmanager_secret_version.config:secret_string.") {
+			t.Errorf("unexpected per-leaf row inside masked subtree: %q", c.Subject)
+		}
+	}
+}
+
 // TestEnrichFromPlanPreservesExisting confirms enrichment doesn't
 // drop or modify the static-side changes — they should appear in
 // the output verbatim alongside the new plan-derived entries, and

--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -78,6 +78,23 @@ type ChangeSet struct {
 	// steps (e.g. [["lifecycle", "0", "ignore_changes"]] or
 	// [["cidr_block"]]).
 	ReplacePaths [][]any `json:"replace_paths,omitempty"`
+	// BeforeSensitive / AfterSensitive shadow Before / After with
+	// boolean leaves indicating which attribute paths are sensitive.
+	// Terraform marks anything that flowed through a sensitive
+	// variable, a sensitive output, or a `sensitive = true` resource
+	// attribute. AttrDeltas consults these to redact values before
+	// they reach the renderer — without redaction a `tflens diff
+	// --enrich-with-plan` against a plan touching e.g. an RDS
+	// password would print the password into CI logs.
+	BeforeSensitive json.RawMessage `json:"before_sensitive,omitempty"`
+	AfterSensitive  json.RawMessage `json:"after_sensitive,omitempty"`
+	// AfterUnknown shadows After with boolean leaves indicating which
+	// attribute values are still `(known after apply)` — i.e.
+	// computed by the provider during apply and not present in the
+	// plan. Without this we'd render those attributes as nil, which
+	// looks like the attribute is being unset rather than just
+	// pending.
+	AfterUnknown json.RawMessage `json:"after_unknown,omitempty"`
 }
 
 // IsNoOp reports whether the change is a refresh-only entry (Actions
@@ -121,11 +138,25 @@ func (c ChangeSet) IsUpdate() bool {
 // (`tags.Name`, `cidr_block`, `vpc_config.0.subnet_ids`); Before /
 // After are the JSON-decoded values; ForceNew is true when this
 // path appears in the parent ChangeSet's ReplacePaths.
+//
+// BeforeSensitive / AfterSensitive mark whether the value at that
+// path was tagged sensitive in the corresponding sensitive-shadow
+// tree. Renderers must redact the value (print "(sensitive)" instead
+// of the raw before/after) when the corresponding flag is set.
+//
+// AfterUnknown marks a value that's still `(known after apply)` —
+// the provider will fill it in during apply, so the plan's After is
+// just a placeholder (typically null) rather than a real value being
+// written. Renderers should print "(known after apply)" instead of
+// the raw After in that case.
 type AttrDelta struct {
-	Path     string
-	Before   any
-	After    any
-	ForceNew bool
+	Path            string
+	Before          any
+	After           any
+	ForceNew        bool
+	BeforeSensitive bool
+	AfterSensitive  bool
+	AfterUnknown    bool
 }
 
 // AttrDeltas walks the before/after attribute trees and returns the
@@ -137,6 +168,14 @@ type AttrDelta struct {
 // with Before=nil. nil after (pure delete) → every before attribute
 // becomes a delta with After=nil. The IsNoOp short-circuit upstream
 // avoids calling AttrDeltas on no-op changes.
+//
+// Sensitive-shadow trees (BeforeSensitive / AfterSensitive) and the
+// AfterUnknown shadow are walked alongside the data. At each leaf,
+// the corresponding bool from the shadow surfaces as a flag on the
+// emitted AttrDelta. Subtree-wide markers (a `true` in the shadow
+// at a non-leaf position) emit a single AttrDelta at that level
+// rather than descending — there's no per-leaf data to compare when
+// the entire subtree is opaque.
 func (c ChangeSet) AttrDeltas() []AttrDelta {
 	var before, after any
 	if len(c.Before) > 0 && string(c.Before) != "null" {
@@ -145,10 +184,26 @@ func (c ChangeSet) AttrDeltas() []AttrDelta {
 	if len(c.After) > 0 && string(c.After) != "null" {
 		_ = json.Unmarshal(c.After, &after)
 	}
+	beforeSens := decodeShadow(c.BeforeSensitive)
+	afterSens := decodeShadow(c.AfterSensitive)
+	afterUnk := decodeShadow(c.AfterUnknown)
 	forceNew := pathSet(c.ReplacePaths)
 	var out []AttrDelta
-	walkDelta(before, after, "", forceNew, &out)
+	walkDelta(before, after, beforeSens, afterSens, afterUnk, "", forceNew, &out)
 	return out
+}
+
+// decodeShadow JSON-decodes a sensitive/unknown shadow tree. Returns
+// nil when the shadow is empty or the literal "null" — a missing
+// shadow means "nothing in this subtree is sensitive/unknown" rather
+// than some kind of error.
+func decodeShadow(raw json.RawMessage) any {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var v any
+	_ = json.Unmarshal(raw, &v)
+	return v
 }
 
 // pathSet flattens the [][]any ReplacePaths into a string set keyed
@@ -187,9 +242,52 @@ func joinPath(steps []any) string {
 // accumulator starts empty and grows with "key" / "<index>" segments
 // as recursion descends. Force-new flag is looked up by the final
 // dot-joined path string.
-func walkDelta(before, after any, path string, forceNew map[string]bool, out *[]AttrDelta) {
-	// Equal — nothing to emit; recursion stops here.
-	if reflect.DeepEqual(before, after) {
+//
+// The three shadow trees (beforeSens / afterSens / afterUnk) are
+// drilled in parallel: at each step shadowKey/shadowIdx returns the
+// matching child shadow, which may be a bool (subtree-wide marker),
+// a map / list (continue drilling), or nil (no marker). When a
+// shadow is `true` at the current level we stop descending and emit
+// a single AttrDelta carrying the marker — terraform represents a
+// fully sensitive/unknown subtree this way (the data side is opaque
+// or empty), so there's no inner content worth diffing.
+func walkDelta(before, after, beforeSens, afterSens, afterUnk any,
+	path string, forceNew map[string]bool, out *[]AttrDelta) {
+	beforeSensBool := isShadowTrue(beforeSens)
+	afterSensBool := isShadowTrue(afterSens)
+	afterUnkBool := isShadowTrue(afterUnk)
+	// A shadow `true` at a structured (map/list) position is terraform
+	// saying "the whole subtree is sensitive/unknown" — the inner
+	// contents are either elided or just placeholder values. Emit one
+	// leaf here carrying the marker rather than descending and
+	// generating a spray of opaque per-attribute deltas.
+	shadowMasksSubtree := (afterUnkBool || afterSensBool || beforeSensBool) &&
+		(hasStructuralChildren(before) || hasStructuralChildren(after))
+	if shadowMasksSubtree {
+		// Sensitive markers alone don't constitute a change — only emit
+		// when the data side actually differs OR the after is unknown
+		// (since unknown means a write is happening, even if before/
+		// after compare equal because both are placeholder nulls).
+		if reflect.DeepEqual(before, after) && !afterUnkBool {
+			return
+		}
+		*out = append(*out, AttrDelta{
+			Path:            path,
+			Before:          before,
+			After:           after,
+			ForceNew:        forceNew[path],
+			BeforeSensitive: beforeSensBool,
+			AfterSensitive:  afterSensBool,
+			AfterUnknown:    afterUnkBool,
+		})
+		return
+	}
+
+	// Equal — nothing to emit; recursion stops here. Exception: if
+	// after-is-unknown, we still want to surface the change (the
+	// values look equal because both are placeholder nulls, but the
+	// provider IS going to compute a new value).
+	if reflect.DeepEqual(before, after) && !afterUnkBool {
 		return
 	}
 	bm, bIsMap := before.(map[string]any)
@@ -205,7 +303,9 @@ func walkDelta(before, after any, path string, forceNew map[string]bool, out *[]
 			} else {
 				child = child + "." + k
 			}
-			walkDelta(bm[k], am[k], child, forceNew, out)
+			walkDelta(bm[k], am[k],
+				shadowKey(beforeSens, k), shadowKey(afterSens, k), shadowKey(afterUnk, k),
+				child, forceNew, out)
 		}
 		return
 	}
@@ -214,11 +314,8 @@ func walkDelta(before, after any, path string, forceNew map[string]bool, out *[]
 	if bIsSlice || aIsSlice {
 		// Lists: recurse positionally up to the longer side. Index
 		// becomes a string segment to match Terraform's path encoding.
-		n := len(bs)
-		if len(as) > n {
-			n = len(as)
-		}
-		for i := 0; i < n; i++ {
+		n := max(len(bs), len(as))
+		for i := range n {
 			var bv, av any
 			if i < len(bs) {
 				bv = bs[i]
@@ -233,17 +330,73 @@ func walkDelta(before, after any, path string, forceNew map[string]bool, out *[]
 			} else {
 				child = child + "." + idx
 			}
-			walkDelta(bv, av, child, forceNew, out)
+			walkDelta(bv, av,
+				shadowIdx(beforeSens, i), shadowIdx(afterSens, i), shadowIdx(afterUnk, i),
+				child, forceNew, out)
 		}
 		return
 	}
-	// Leaf — emit the delta. Force-new lookup uses the final path.
+	// Leaf — emit the delta. Force-new lookup uses the final path;
+	// shadow flags carry whatever sensitivity / unknown markers
+	// applied at this exact path.
 	*out = append(*out, AttrDelta{
-		Path:     path,
-		Before:   before,
-		After:    after,
-		ForceNew: forceNew[path],
+		Path:            path,
+		Before:          before,
+		After:           after,
+		ForceNew:        forceNew[path],
+		BeforeSensitive: beforeSensBool,
+		AfterSensitive:  afterSensBool,
+		AfterUnknown:    afterUnkBool,
 	})
+}
+
+// isShadowTrue returns true when a shadow value is the literal `true`
+// — i.e. "this entire subtree is sensitive/unknown". A nested map or
+// list shadow returns false (the markers are deeper); nil returns
+// false (no marker).
+func isShadowTrue(v any) bool {
+	b, ok := v.(bool)
+	return ok && b
+}
+
+// shadowKey looks up a key in a map-shaped shadow value. Returns nil
+// when the shadow isn't a map or doesn't have the key — both mean
+// "no marker at this child".
+func shadowKey(shadow any, k string) any {
+	m, ok := shadow.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return m[k]
+}
+
+// shadowIdx looks up an index in a list-shaped shadow value. Returns
+// nil when the shadow isn't a list or the index is out of bounds.
+func shadowIdx(shadow any, i int) any {
+	s, ok := shadow.([]any)
+	if !ok {
+		return nil
+	}
+	if i < 0 || i >= len(s) {
+		return nil
+	}
+	return s[i]
+}
+
+// hasStructuralChildren reports whether a value is a non-empty map or
+// list — i.e. has children we could descend into. Used to decide
+// whether a sensitive marker at this level should mask the subtree
+// (no children to descend, so emit one leaf) or be inherited as the
+// caller drills into the children themselves (which is the normal
+// per-leaf path).
+func hasStructuralChildren(v any) bool {
+	switch x := v.(type) {
+	case map[string]any:
+		return len(x) > 0
+	case []any:
+		return len(x) > 0
+	}
+	return false
 }
 
 // mergeMapKeys returns the sorted union of keys in two maps. Used by

--- a/pkg/plan/plan_test.go
+++ b/pkg/plan/plan_test.go
@@ -118,6 +118,69 @@ func TestAttrDeltasCreateAndDelete(t *testing.T) {
 	}
 }
 
+// TestAttrDeltasSensitiveAndUnknown pins the shadow-tree handling.
+// The fixture's RDS resource has a sensitive `password` (per-leaf
+// shadow), an unchanged-but-redacted `username`, and an `arn` that's
+// going from a real value to `(known after apply)`. The secret-
+// manager resource has a fully sensitive structured value (subtree-
+// wide shadow) where the entire `secret_string` map is masked.
+//
+// Expectations:
+//   - password: emit one delta with BeforeSensitive + AfterSensitive
+//   - engine_version: emit one delta, no sensitivity flags
+//   - arn: emit one delta with AfterUnknown
+//   - secret_string: emit ONE delta at the subtree level (don't
+//     descend into db_pass / api_key — those are masked by the
+//     subtree-wide sensitive marker)
+func TestAttrDeltasSensitiveAndUnknown(t *testing.T) {
+	p, err := plan.Load(fixturePath("sensitive_and_unknown.json"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	rdsDeltas := p.ResourceChanges[0].Change.AttrDeltas()
+	byPath := map[string]plan.AttrDelta{}
+	for _, d := range rdsDeltas {
+		byPath[d.Path] = d
+	}
+
+	if pw, ok := byPath["password"]; !ok {
+		t.Errorf("missing password delta")
+	} else {
+		if !pw.BeforeSensitive || !pw.AfterSensitive {
+			t.Errorf("password delta should be marked sensitive on both sides; got %+v", pw)
+		}
+		if pw.AfterUnknown {
+			t.Errorf("password delta should NOT be marked unknown")
+		}
+	}
+
+	if ev, ok := byPath["engine_version"]; !ok {
+		t.Errorf("missing engine_version delta")
+	} else if ev.BeforeSensitive || ev.AfterSensitive || ev.AfterUnknown {
+		t.Errorf("engine_version should have no shadow flags; got %+v", ev)
+	}
+
+	if arn, ok := byPath["arn"]; !ok {
+		t.Errorf("missing arn delta — known-after-apply should still surface")
+	} else if !arn.AfterUnknown {
+		t.Errorf("arn delta should be AfterUnknown; got %+v", arn)
+	}
+
+	// Subtree-masked sensitive structured value — emit one delta at
+	// `secret_string`, NOT per-leaf entries for db_pass / api_key.
+	secretDeltas := p.ResourceChanges[1].Change.AttrDeltas()
+	if len(secretDeltas) != 1 {
+		t.Fatalf("secret_string deltas len = %d, want 1; got %+v", len(secretDeltas), secretDeltas)
+	}
+	if secretDeltas[0].Path != "secret_string" {
+		t.Errorf("secret delta path = %q, want secret_string", secretDeltas[0].Path)
+	}
+	if !secretDeltas[0].BeforeSensitive || !secretDeltas[0].AfterSensitive {
+		t.Errorf("secret_string subtree should be marked sensitive on both sides; got %+v", secretDeltas[0])
+	}
+}
+
 // TestAddressParsingNestedModule exercises the address parser
 // against `module.X.module.Y.<type>.<name>[<index>]` shape. Plus
 // the `data.<type>.<name>` data-source variant.

--- a/pkg/plan/testdata/sensitive_and_unknown.json
+++ b/pkg/plan/testdata/sensitive_and_unknown.json
@@ -1,0 +1,60 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.7.0",
+  "resource_changes": [
+    {
+      "address": "aws_db_instance.main",
+      "mode": "managed",
+      "type": "aws_db_instance",
+      "name": "main",
+      "change": {
+        "actions": ["update"],
+        "before": {
+          "password": "hunter2",
+          "username": "admin",
+          "engine_version": "14.5",
+          "arn": "arn:aws:rds:us-east-1:123:db:main"
+        },
+        "after": {
+          "password": "correcthorsebatterystaple",
+          "username": "admin",
+          "engine_version": "15.1",
+          "arn": null
+        },
+        "before_sensitive": {
+          "password": true
+        },
+        "after_sensitive": {
+          "password": true
+        },
+        "after_unknown": {
+          "arn": true
+        },
+        "replace_paths": []
+      }
+    },
+    {
+      "address": "aws_secretsmanager_secret_version.config",
+      "mode": "managed",
+      "type": "aws_secretsmanager_secret_version",
+      "name": "config",
+      "change": {
+        "actions": ["update"],
+        "before": {
+          "secret_string": {"db_pass": "old", "api_key": "old"}
+        },
+        "after": {
+          "secret_string": {"db_pass": "new", "api_key": "new"}
+        },
+        "before_sensitive": {
+          "secret_string": true
+        },
+        "after_sensitive": {
+          "secret_string": true
+        },
+        "after_unknown": {},
+        "replace_paths": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Three quality improvements to `tflens diff --enrich-with-plan` that came out of dogfooding the 0.11.x baseline against real plans:

- **Sensitive value redaction.** Plan attributes flagged via `before_sensitive` / `after_sensitive` (anything that flowed through a sensitive variable, sensitive output, or `sensitive = true` resource attribute) now render as `(sensitive)` instead of the raw value. Without this, a `tflens diff --enrich-with-plan` against a plan touching e.g. an RDS password would write the password into CI logs the moment a reviewer ran it. Subtree-wide markers (entire structured value sensitive — `aws_secretsmanager_secret_version.secret_string` being the canonical example) collapse to a single `(sensitive)` row at the subtree level rather than descending into placeholder children.
- **`(known after apply)` rendering.** Plan attributes whose post-apply value is computed by the provider (the plan's `after_unknown` shadow) render as `(known after apply)` instead of `<nil>` — so `aws_db_instance.main:arn` showing `→ (known after apply)` is unambiguously "the provider will fill this in" rather than "the attribute is being unset". The walker emits a delta even when before/after compare equal (both are placeholder nulls until apply fills the value in).
- **Per-module routing.** Plan-derived findings whose module address matches a paired module call land under that pair's section instead of all collapsing into the project-root section. New `diff.EnrichResultsFromPlan(results, rootChanges, plan, project)` entry point converts each plan ResourceChange's `module_address` (with count/for_each indices stripped) to the dotted-key form `loader.ModuleCallPair` uses, then routes accordingly. Unmatched module addresses fall through to rootChanges so a stale plan referencing a missing module is still visible.

The flat `EnrichFromPlan` is retained as a thin wrapper around the now-shared `changesForResourceChange` helper for callers that don't have a results slice.

## Test plan

- [x] `make check` passes
- [x] New `TestAttrDeltasSensitiveAndUnknown` confirms per-leaf flag propagation and subtree-masking behaviour against the new `sensitive_and_unknown.json` fixture
- [x] New `TestEnrichFromPlanRedactsSensitiveAndUnknown` pins that the rendered Detail strings substitute markers correctly and never leak the raw values
- [x] New `TestEnrichResultsFromPlanRoutesByModule` and `TestEnrichResultsFromPlanFallsBackToRoot` pin the routing behaviour
- [x] Existing tests for `pkg/plan` and `pkg/diff` enrichment still pass — backward-compatible: fixtures without the new shadow fields decode to nil shadows and behave exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)