### PR TITLE
Add GitHub Action wrapper (uses: dgr237/tflens@vX.Y.Z)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to tflens are documented here. The format is loosely based o
 
 ## [Unreleased]
 
+### Added
+
+- **GitHub Action wrapper (`uses: dgr237/tflens@vX.Y.Z`).** Composite action at the repo root packages `tflens diff | whatif | statediff | validate` with PR-comment plumbing so CI integration is a single `uses:` line. Inputs map 1:1 to the flags (`command`, `path`, `ref`, `format`, `plan`, `state`, `args`) plus PR-comment controls (`comment-on-pr`, `comment-tag`, `pr-number`, `step-summary`, `fail-on-breaking`). Outputs: `output-file` (path), `exit-code` (numeric), `breaking` (boolean string). Builds tflens from the action's own checkout via `${{ github.action_path }}` so the binary version stays in lockstep with the action ref the consumer pinned (`dgr237/tflens@v0.12.0` always runs tflens v0.12.0; no separate `version` input to drift). Sticky PR comment uses a hidden marker line (`<!-- tflens-action:<tag> -->`) so re-runs find + PATCH the existing comment instead of stacking new ones; body is JSON-encoded via `jq --rawfile` so backticks / `$vars` / quotes inside the markdown can't break the request shape. Default `comment-tag` is `tflens` — workflows that invoke the action twice (e.g. diff + statediff) should pass distinct tags so the comments don't overwrite each other. Step summary append (`$GITHUB_STEP_SUMMARY`) and PR commenting both skip silently when `format != markdown`. Documented in the new "GitHub Action" section of the README with a worked plan-enrichment example.
+
 ## [0.12.0] — 2026-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,6 +49,54 @@ tflens --format markdown diff --ref main ./my-tf | gh pr comment $PR --body-file
 tflens --offline diff --ref main ./my-tf
 ```
 
+## GitHub Action
+
+A composite action wrapper lives at the repo root, so a workflow can invoke `tflens diff --format markdown --enrich-with-plan` and post the result as a sticky PR comment in one step:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write   # required for the sticky comment
+
+jobs:
+  tflens:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # tflens needs history for --ref comparison
+
+      # Optional: produce a plan to enrich the diff with attribute-level deltas
+      - run: terraform init && terraform plan -out=tfplan && terraform show -json tfplan > plan.json
+
+      - uses: dgr237/tflens@v0.12.0
+        with:
+          command: diff
+          ref: origin/${{ github.base_ref }}
+          plan: plan.json
+```
+
+The action builds tflens from the same ref the consumer pinned (so `dgr237/tflens@v0.12.0` always runs tflens v0.12.0) and posts the markdown output as a sticky PR comment — subsequent runs edit the same comment via a hidden marker (`<!-- tflens-action:tflens -->`) instead of stacking new ones. Every run also appends to `$GITHUB_STEP_SUMMARY` for visibility on the workflow run page.
+
+Inputs (all optional):
+
+| Input | Default | Notes |
+|---|---|---|
+| `command` | `diff` | `diff` / `whatif` / `statediff` / `validate` |
+| `path` | `.` | Project path |
+| `ref` | `auto` | Git ref for diff/whatif/statediff. `auto` resolves to @{upstream} → origin/HEAD → main → master |
+| `format` | `markdown` | `markdown` / `json` / `text`. PR commenting and step summary skip silently for non-markdown |
+| `plan` | _(empty)_ | Path to `terraform show -json` output. Forwarded as `--enrich-with-plan` (diff only) |
+| `state` | _(empty)_ | Path to a Terraform state file. Forwarded as `--state` (statediff only) |
+| `args` | _(empty)_ | Raw extra args appended to the command (e.g. `--offline`) |
+| `comment-on-pr` | `true` | Post / edit a sticky PR comment |
+| `comment-tag` | `tflens` | Marker used to identify the sticky comment. Use distinct tags when calling the action multiple times in one workflow |
+| `pr-number` | _(empty)_ | PR number to comment on. Required for non-`pull_request` triggers |
+| `step-summary` | `true` | Append output to `$GITHUB_STEP_SUMMARY` |
+| `fail-on-breaking` | `true` | Exit non-zero when tflens reports findings (CI gate) |
+
+Outputs: `output-file` (path to captured output), `exit-code` (numeric), `breaking` (`true` / `false`).
+
 ## Commands
 
 | Command | Purpose |

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,248 @@
+name: 'tflens'
+description: |
+  Run tflens (static Terraform analyser) against a Terraform project and
+  surface the result as a sticky PR comment + workflow step summary.
+  Wraps `tflens diff | whatif | statediff | validate` with PR-comment
+  plumbing so CI integration is a single uses: line.
+author: 'dgr237'
+branding:
+  icon: 'eye'
+  color: 'purple'
+
+inputs:
+  command:
+    description: 'Subcommand to run: diff | whatif | statediff | validate.'
+    required: false
+    default: 'diff'
+  path:
+    description: 'Project path passed to the subcommand. Defaults to the workspace root.'
+    required: false
+    default: '.'
+  ref:
+    description: |
+      Git ref for diff / whatif / statediff to compare against. Default
+      `auto` resolves to @{upstream} → origin/HEAD → main → master.
+      Ignored by `validate`.
+    required: false
+    default: 'auto'
+  format:
+    description: |
+      Output format: `markdown` (default — best for PR comments and
+      step summaries), `json`, or `text`.
+    required: false
+    default: 'markdown'
+  plan:
+    description: |
+      Path to a `terraform show -json` plan file. Forwarded as
+      `--enrich-with-plan` when set. Only honoured by `diff`.
+    required: false
+    default: ''
+  state:
+    description: |
+      Path to a Terraform state file. Forwarded as `--state` when set.
+      Only honoured by `statediff`.
+    required: false
+    default: ''
+  args:
+    description: |
+      Raw extra arguments appended verbatim to the tflens command.
+      Word-split on whitespace (no quoting). Use this for flags the
+      action doesn't model directly (e.g. `--offline`).
+    required: false
+    default: ''
+  comment-on-pr:
+    description: |
+      Post the markdown output as a sticky PR comment. Subsequent runs
+      EDIT the same comment (matched by `comment-tag`) instead of
+      stacking new ones. Requires `pull-requests: write` permission and
+      either a `pull_request`-event trigger or `pr-number` set
+      explicitly. Skipped silently when format != `markdown`.
+    required: false
+    default: 'true'
+  comment-tag:
+    description: |
+      Marker used to identify the sticky comment so re-runs find +
+      edit the same one. Use distinct tags when calling this action
+      multiple times in one workflow (e.g. `tflens-diff` /
+      `tflens-statediff`) so the comments don't overwrite each other.
+    required: false
+    default: 'tflens'
+  pr-number:
+    description: |
+      PR number to comment on. Required when the workflow isn't
+      triggered by `pull_request` (e.g. a `workflow_dispatch` test
+      run). Falls back to `github.event.pull_request.number` when
+      empty.
+    required: false
+    default: ''
+  step-summary:
+    description: |
+      Append the markdown output to `$GITHUB_STEP_SUMMARY` for
+      visibility on the workflow run page. Skipped silently when
+      format != `markdown`.
+    required: false
+    default: 'true'
+  fail-on-breaking:
+    description: |
+      Exit the step with the underlying tflens exit code (non-zero
+      when breaking changes / direct impact / flagged resources are
+      detected). Set to `false` to surface findings without gating
+      the run.
+    required: false
+    default: 'true'
+
+outputs:
+  output-file:
+    description: 'Path to the captured tflens output on the runner filesystem.'
+    value: ${{ steps.run.outputs.output-file }}
+  exit-code:
+    description: 'Numeric exit code from tflens (0 = clean, 1 = findings detected).'
+    value: ${{ steps.run.outputs.exit-code }}
+  breaking:
+    description: '`true` when `exit-code != 0`, otherwise `false`.'
+    value: ${{ steps.run.outputs.breaking }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        # Read the go directive from the action's own checked-out
+        # go.mod rather than hardcoding — keeps the toolchain version
+        # in lockstep with the source. github.action_path resolves to
+        # the action's own checkout (NOT the consumer's workspace).
+        go-version-file: '${{ github.action_path }}/go.mod'
+        check-latest: true
+
+    - name: Build tflens
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        # Build from the action's own source tree so the binary
+        # version matches the action ref the consumer pinned (e.g.
+        # uses: dgr237/tflens@v0.12.0 ⇒ tflens v0.12.0). Avoids a
+        # round-trip to proxy.golang.org and avoids a separate
+        # version input getting out of sync with the action ref.
+        out_dir="${RUNNER_TEMP:-/tmp}/tflens-bin"
+        mkdir -p "${out_dir}"
+        ( cd "${ACTION_PATH}" && go build -o "${out_dir}/tflens" . )
+        echo "${out_dir}" >> "$GITHUB_PATH"
+
+    - name: Run tflens
+      id: run
+      shell: bash
+      env:
+        TFLENS_COMMAND: ${{ inputs.command }}
+        TFLENS_PATH: ${{ inputs.path }}
+        TFLENS_REF: ${{ inputs.ref }}
+        TFLENS_FORMAT: ${{ inputs.format }}
+        TFLENS_PLAN: ${{ inputs.plan }}
+        TFLENS_STATE: ${{ inputs.state }}
+        TFLENS_EXTRA_ARGS: ${{ inputs.args }}
+      run: |
+        # Don't `set -e` — we want to capture tflens's exit code
+        # rather than aborting the step when it's non-zero.
+        set -uo pipefail
+        out_file="$(mktemp -t tflens-output.XXXXXX)"
+        cmd=( tflens --format "${TFLENS_FORMAT}" "${TFLENS_COMMAND}" )
+        case "${TFLENS_COMMAND}" in
+          diff|whatif|statediff)
+            cmd+=( --ref "${TFLENS_REF}" )
+            ;;
+        esac
+        if [ -n "${TFLENS_PLAN}" ] && [ "${TFLENS_COMMAND}" = "diff" ]; then
+          cmd+=( --enrich-with-plan "${TFLENS_PLAN}" )
+        fi
+        if [ -n "${TFLENS_STATE}" ] && [ "${TFLENS_COMMAND}" = "statediff" ]; then
+          cmd+=( --state "${TFLENS_STATE}" )
+        fi
+        if [ -n "${TFLENS_EXTRA_ARGS}" ]; then
+          # Word-split on whitespace — documented behaviour, since
+          # composite actions can't pass arrays as inputs.
+          # shellcheck disable=SC2206
+          extra=( ${TFLENS_EXTRA_ARGS} )
+          cmd+=( "${extra[@]}" )
+        fi
+        cmd+=( "${TFLENS_PATH}" )
+        echo "::group::tflens command"
+        printf '%q ' "${cmd[@]}"; echo
+        echo "::endgroup::"
+        "${cmd[@]}" > "${out_file}"
+        ec=$?
+        {
+          echo "exit-code=${ec}"
+          if [ "${ec}" -ne 0 ]; then
+            echo "breaking=true"
+          else
+            echo "breaking=false"
+          fi
+          echo "output-file=${out_file}"
+        } >> "$GITHUB_OUTPUT"
+        echo "::group::tflens output"
+        cat "${out_file}"
+        echo "::endgroup::"
+
+    - name: Append to step summary
+      if: ${{ inputs.step-summary == 'true' && inputs.format == 'markdown' }}
+      shell: bash
+      env:
+        OUTPUT_FILE: ${{ steps.run.outputs.output-file }}
+      run: |
+        set -euo pipefail
+        cat "${OUTPUT_FILE}" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Sticky PR comment
+      if: ${{ inputs.comment-on-pr == 'true' && inputs.format == 'markdown' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        OUTPUT_FILE: ${{ steps.run.outputs.output-file }}
+        COMMENT_TAG: ${{ inputs.comment-tag }}
+        PR_NUMBER_OVERRIDE: ${{ inputs.pr-number }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        if [ -n "${PR_NUMBER_OVERRIDE}" ]; then
+          pr="${PR_NUMBER_OVERRIDE}"
+        elif [ -n "${EVENT_PR_NUMBER}" ]; then
+          pr="${EVENT_PR_NUMBER}"
+        else
+          echo "no PR number available (not a pull_request event and pr-number not set) — skipping sticky comment" >&2
+          exit 0
+        fi
+        marker="<!-- tflens-action:${COMMENT_TAG} -->"
+        body_file="$(mktemp)"
+        {
+          echo "${marker}"
+          cat "${OUTPUT_FILE}"
+        } > "${body_file}"
+        # Find an existing comment by the marker line (prefix match)
+        # and edit it; create a new one when none exists. jq's
+        # --rawfile JSON-encodes the body so backticks / dollar-signs
+        # / quotes inside the markdown can't break the request shape.
+        existing="$(gh api "repos/${REPO}/issues/${pr}/comments" --paginate \
+          --jq ".[] | select(.body | startswith(\"${marker}\")) | .id" | head -n1)"
+        if [ -n "${existing}" ]; then
+          jq -n --rawfile body "${body_file}" '{body: $body}' \
+            | gh api "repos/${REPO}/issues/comments/${existing}" \
+                --method PATCH --input - >/dev/null
+          echo "edited existing comment ${existing}"
+        else
+          jq -n --rawfile body "${body_file}" '{body: $body}' \
+            | gh api "repos/${REPO}/issues/${pr}/comments" \
+                --method POST --input - >/dev/null
+          echo "created new comment"
+        fi
+
+    - name: Gate on findings
+      if: ${{ inputs.fail-on-breaking == 'true' && steps.run.outputs.breaking == 'true' }}
+      shell: bash
+      env:
+        EXIT_CODE: ${{ steps.run.outputs.exit-code }}
+      run: |
+        echo "tflens reported breaking changes / findings (exit ${EXIT_CODE})" >&2
+        exit "${EXIT_CODE}"


### PR DESCRIPTION
## Summary

Composite GitHub Action wrapper at the repo root so consumers can integrate `tflens` into their CI in one `uses:` line:

```yaml
- uses: dgr237/tflens@v0.13.0
  with:
    command: diff
    ref: origin/${{ github.base_ref }}
    plan: plan.json
```

This packages everything we shipped in 0.11.x and 0.12.0 (markdown renderer + plan enrichment + sensitive redaction + per-module routing) into a one-liner consumers can drop into a workflow. The action:

- **Builds tflens from its own checkout** (`${{ github.action_path }}`) rather than `go install` — the binary version stays in lockstep with the pinned action ref, no separate `version` input to drift.
- **Runs the chosen subcommand** (`diff` / `whatif` / `statediff` / `validate`) with format defaulting to `markdown`.
- **Posts a sticky PR comment** with a hidden marker line (`<!-- tflens-action:<tag> -->`) so re-runs PATCH the existing comment instead of stacking new ones. Body is JSON-encoded via `jq --rawfile` so backticks / `$vars` / quotes inside the markdown can't break the request shape.
- **Appends to `$GITHUB_STEP_SUMMARY`** for visibility on the workflow run page.
- **Optionally gates the run** (`fail-on-breaking: true` by default) so a breaking finding fails the step.

Inputs (all optional): `command`, `path`, `ref`, `format`, `plan`, `state`, `args`, `comment-on-pr`, `comment-tag`, `pr-number`, `step-summary`, `fail-on-breaking`.
Outputs: `output-file`, `exit-code`, `breaking`.

The action lives at `action.yml` in the repo root rather than in a separate `dgr237/tflens-action` repo so the version of tflens and the version of the action wrapper are inherently the same — pinning `dgr237/tflens@v0.13.0` always runs tflens v0.13.0.

## Test plan

- [x] `action.yml` parses as valid YAML
- [ ] Wire the action into this repo's own CI (or a sister repo) on a PR with a known breaking change to confirm the sticky comment posts + edits correctly
- [ ] Verify the `breaking` / `fail-on-breaking` gating works end-to-end (a clean PR shouldn't fail; a breaking PR should)
- [ ] Verify `step-summary` populates the workflow run page

The two unchecked items can't be tested without a real workflow run; we'll exercise them on the first consumer integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)