### PR TITLE
plan enrichment: extend to whatif and statediff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to tflens are documented here. The format is loosely based o
 
 ## [Unreleased]
 
+### Added
+
+- **`tflens whatif --enrich-with-plan plan.json`** — plan enrichment is no longer diff-only. Plan-derived findings whose module address matches a call's pair key land inside that call's `APIChanges`, alongside the static-side API diff for the same call. Plan rows whose module address has no matching call are dropped silently — whatif is per-call only; root-level coverage stays with `tflens diff --enrich-with-plan`. Plan-derived Breaking findings are added to the existing DirectImpact total so the CI exit code reflects them too — a force-new attribute change in a child IS a consumer concern even when the parent's USE cross-validates cleanly. New `diff.EnrichWhatifsFromPlan(calls, plan, project)` entry point. The shared per-rc loop (no-op + stale-move skipping, source-position attribution) was extracted into a new `walkPlanChanges(p, project, route)` helper that all three of `EnrichFromPlan` / `EnrichResultsFromPlan` / `EnrichWhatifsFromPlan` now compose with their own routing strategy.
+
+- **`tflens statediff --enrich-with-plan plan.json`** — the higher-value half of the change. Statediff's static analysis flags resources whose `count` / `for_each` expression depends on a changed local or variable default — the "this CAN recompute" signal. Plan enrichment pairs that with the plan's "here are the N concrete instances that WILL be affected": each `AffectedResource` gets a `PlanInstances` list with per-instance plan addresses (including count/for_each indices) and the action list terraform will take (`["update"]`, `["delete", "create"]`, etc.). Turns "this change touches a count expression" into "this change destroys aws_subnet.foo[0], updates aws_subnet.foo[1] in place, and creates aws_subnet.foo[2]" — much more actionable for the reviewer. New `(*statediff.Result).EnrichWithPlan(plan)` method; `cmd/statediff.go` gains the `--enrich-with-plan` flag. New `Mode string` field on `AffectedResource` (`"managed"` / `"data"`, with `omitempty` so existing JSON consumers aren't broken) — needed to reconstruct the plan-side address shape correctly for data sources (which carry a `data.` prefix). New `PlanInstance` type + `PlanInstances []PlanInstance` field on `AffectedResource`. Console renderer adds a `• plan: <address> [actions]` line under each affected resource; markdown renderer adds a `📋 plan:` row.
+
 ## [0.14.0] — 2026-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -252,7 +252,8 @@ Root module:
 
 - **`count`/`for_each` instances all roll up to the same source-side entity.** Plan addresses like `aws_subnet.foo[0]` / `aws_subnet.foo["us-east-1"]` resolve to the single source-side `resource.aws_subnet.foo` declaration (matching by index-stripped path), but each indexed instance still gets its own Change row with the full plan address — including the index — preserved in the Subject. So `aws_subnet.foo[0]:cidr_block` and `aws_subnet.foo[1]:cidr_block` are visually distinct in the output. Indexed module calls (`module.regions["us-east-1"]`) match the same way: the source-side `module.regions` ModuleNode is the lookup target regardless of how many instances the for_each / count produces.
 - **Plan format versions.** Supports format_version 1.x (Terraform 1.0+). Older plans are rejected with a clear error.
-- **`whatif` and `statediff` don't yet take `--enrich-with-plan`** — only `diff` does. Same machinery would slot in cleanly if useful.
+- **`whatif --enrich-with-plan`** layers plan-derived findings onto each call's API-changes section so reviewers see the full picture per call. Plan rows whose module address has no matching call are dropped silently — whatif is per-call only; use `tflens diff --enrich-with-plan` for root-level coverage. Plan-derived Breaking findings count toward the CI exit code in addition to DirectImpact.
+- **`statediff --enrich-with-plan`** pairs the static "this count/for_each expression COULD recompute" signal with the plan's "here are the N concrete instances that WILL be affected." Each `AffectedResource` gets a `PlanInstances` list with the per-instance plan addresses (including count/for_each indices) and the actions terraform will take (`["update"]`, `["delete", "create"]`, etc.). Resources with no plan match leave `PlanInstances` empty — possible reasons: count expanded to 0, plan is stale, or the resource isn't in the plan.
 
 ### What it catches
 

--- a/cmd/statediff.go
+++ b/cmd/statediff.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dgr237/tflens/pkg/config"
 	"github.com/dgr237/tflens/pkg/loader"
+	"github.com/dgr237/tflens/pkg/plan"
 	"github.com/dgr237/tflens/pkg/render"
 	"github.com/dgr237/tflens/pkg/statediff"
 	"github.com/dgr237/tflens/pkg/tfstate"
@@ -53,6 +54,8 @@ func init() {
 	statediffCmd.Flags().String("ref", config.RefAutoKeyword,
 		"git ref to compare against (branch, tag, SHA, …); 'auto' detects @{upstream} → origin/HEAD → main → master")
 	statediffCmd.Flags().String("state", "", "optional Terraform state v4 JSON file for instance cross-reference")
+	statediffCmd.Flags().String("enrich-with-plan", "",
+		"path to a `terraform show -json` plan file. For each AffectedResource flagged by the static analysis, attaches the per-instance actions terraform will actually take ({delete, create}, [update], etc.) so reviewers see 'this change replaces these N concrete instances' instead of just 'this change touches a count expression'.")
 	rootCmd.AddCommand(statediffCmd)
 }
 
@@ -68,6 +71,14 @@ func runStatediff(s config.Settings) error {
 	}
 	result := statediff.Analyze(oldProj, newProj, state)
 	result.BaseRef, result.Path = s.BaseRef, s.Path
+	if s.PlanPath != "" {
+		p, err := plan.Load(s.PlanPath)
+		if err != nil {
+			cleanup()
+			return err
+		}
+		result.EnrichWithPlan(p)
+	}
 	render.New(s).Statediff(&result)
 	if result.FlaggedCount() > 0 {
 		// os.Exit skips the deferred cleanup, so run it explicitly

--- a/cmd/whatif.go
+++ b/cmd/whatif.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dgr237/tflens/pkg/config"
 	"github.com/dgr237/tflens/pkg/diff"
 	"github.com/dgr237/tflens/pkg/loader"
+	"github.com/dgr237/tflens/pkg/plan"
 	"github.com/dgr237/tflens/pkg/render"
 )
 
@@ -52,6 +53,8 @@ The ref defaults to 'auto', which resolves to @{upstream} → origin/HEAD
 func init() {
 	whatifCmd.Flags().String("ref", config.RefAutoKeyword,
 		"git ref to compare against (branch, tag, SHA, …); 'auto' detects @{upstream} → origin/HEAD → main → master")
+	whatifCmd.Flags().String("enrich-with-plan", "",
+		"path to a `terraform show -json` plan file. Plan-derived attribute deltas (force-new attribute changes, replaces, deletes) get layered onto each call's API-changes section so reviewers see the full picture per call. Plan rows whose module address has no matching call are dropped (whatif is per-call only — use `tflens diff --enrich-with-plan` for root-level coverage). Plan-derived Breaking findings count toward the CI exit code in addition to DirectImpact.")
 	rootCmd.AddCommand(whatifCmd)
 }
 
@@ -69,6 +72,19 @@ func runWhatifRef(s config.Settings) error {
 	if filtered {
 		return fmt.Errorf("no module call named %q differs between %s and the path (or call does not exist)", s.OnlyName, s.BaseRef)
 	}
+	if s.PlanPath != "" {
+		p, err := plan.Load(s.PlanPath)
+		if err != nil {
+			cleanup()
+			return err
+		}
+		calls = diff.EnrichWhatifsFromPlan(calls, p, newProj)
+		// Plan-derived Breaking findings count toward the CI gate
+		// in addition to DirectImpact: a force-new attribute change
+		// in a child IS a consumer concern even when the parent's
+		// USE doesn't break (the resource will physically rebuild).
+		totalImpact = countWhatifBreaking(calls)
+	}
 	render.New(s).Whatif(s.BaseRef, s.Path, calls)
 	if totalImpact > 0 {
 		// os.Exit skips the deferred cleanup, so run it explicitly
@@ -78,4 +94,24 @@ func runWhatifRef(s config.Settings) error {
 		os.Exit(1)
 	}
 	return nil
+}
+
+// countWhatifBreaking sums the gating signals across every call:
+// DirectImpact entries (cross-validation failures from the static
+// side) plus plan-derived Breaking findings inside APIChanges. Used
+// after EnrichWhatifsFromPlan to refresh the CI exit-code count so
+// plan-only Breaking changes (e.g. a child resource's force-new
+// attribute) still gate the merge even when the parent's USE
+// cross-validates cleanly.
+func countWhatifBreaking(calls []diff.WhatifResult) int {
+	n := 0
+	for _, r := range calls {
+		n += len(r.DirectImpact)
+		for _, c := range r.APIChanges {
+			if c.Kind == diff.Breaking && c.Source == diff.SourcePlan {
+				n++
+			}
+		}
+	}
+	return n
 }

--- a/pkg/diff/enrich.go
+++ b/pkg/diff/enrich.go
@@ -79,13 +79,29 @@ func EnrichFromPlan(changes []Change, p *plan.Plan, newProj *loader.Project) []C
 	}
 	out := make([]Change, 0, len(changes)+len(p.ResourceChanges))
 	out = append(out, changes...)
+	walkPlanChanges(p, newProj, func(_ string, c Change) {
+		out = append(out, c)
+	})
+	sortChanges(out)
+	return out
+}
 
-	// Build a lookup so we can confirm each plan entry corresponds to
-	// a known source-side entity. Plan entries that match nothing
-	// still get emitted — they're useful (e.g. detecting a resource
-	// added to the plan from outside the diff'd source) — but the
-	// entity-existence lookup tells the renderer not to assume a
-	// source position for them.
+// walkPlanChanges runs the per-rc enrichment loop and dispatches each
+// resulting Change to the caller-supplied route function with the
+// originating plan module_address. Centralises the shared logic of
+// EnrichFromPlan / EnrichResultsFromPlan / EnrichWhatifsFromPlan —
+// each caller routes the same emitted Changes into different
+// destinations (flat list, per-pair Changes, per-call APIChanges).
+//
+// Skips no-ops and the individual halves of detected stale-move
+// pairs; the collapsed stale-move Informational entries are emitted
+// after the main loop, routed by the To-side module path.
+//
+// Nil plan is a no-op so callers don't need to branch on the flag.
+func walkPlanChanges(p *plan.Plan, newProj *loader.Project, route func(moduleAddress string, c Change)) {
+	if p == nil {
+		return
+	}
 	projectEntities := buildEntityIndex(newProj)
 	movedIdx := buildMovedIndex(newProj)
 	stale := detectStalePlanMoves(p.ResourceChanges, movedIdx)
@@ -99,12 +115,14 @@ func EnrichFromPlan(changes []Change, p *plan.Plan, newProj *loader.Project) []C
 			continue
 		}
 		exists, pos := lookupEntity(projectEntities, rc)
-		out = append(out, changesForResourceChange(rc, exists, pos)...)
+		for _, c := range changesForResourceChange(rc, exists, pos) {
+			route(rc.ModuleAddress, c)
+		}
 	}
-	out = append(out, stalePlanMoveChanges(stale, projectEntities)...)
-
-	sortChanges(out)
-	return out
+	for _, m := range stale {
+		c := stalePlanMoveChange(m, projectEntities)
+		route(moduleAddressOf(m.To), c)
+	}
 }
 
 // EnrichResultsFromPlan is the per-module-aware variant of
@@ -142,47 +160,64 @@ func EnrichResultsFromPlan(results []PairResult, rootChanges []Change,
 			pairIdx[r.Pair.Key] = i
 		}
 	}
-	projectEntities := buildEntityIndex(newProj)
-	movedIdx := buildMovedIndex(newProj)
-	stale := detectStalePlanMoves(p.ResourceChanges, movedIdx)
-	deleteSkip, createSkip := stalePlanMoveSkipSets(stale)
 	mergedRoot := append([]Change(nil), rootChanges...)
-
-	route := func(moduleAddress string, change Change) {
+	walkPlanChanges(p, newProj, func(moduleAddress string, c Change) {
 		key := planModuleKey(moduleAddress)
 		if i, ok := pairIdx[key]; ok {
-			results[i].Changes = append(results[i].Changes, change)
+			results[i].Changes = append(results[i].Changes, c)
 			return
 		}
-		mergedRoot = append(mergedRoot, change)
-	}
-
-	for _, rc := range p.ResourceChanges {
-		if rc.Change.IsNoOp() {
-			continue
-		}
-		if shouldSkipForStaleMove(rc, deleteSkip, createSkip) {
-			continue
-		}
-		exists, pos := lookupEntity(projectEntities, rc)
-		for _, c := range changesForResourceChange(rc, exists, pos) {
-			route(rc.ModuleAddress, c)
-		}
-	}
-	// Stale-move entries route by the To address's module path (the
-	// destination — that's where the resource will live going
-	// forward, so the entry sits next to whatever other plan-derived
-	// rows for that module landed in the same pair).
-	for _, m := range stale {
-		c := stalePlanMoveChange(m, projectEntities)
-		route(moduleAddressOf(m.To), c)
-	}
-
+		mergedRoot = append(mergedRoot, c)
+	})
 	for i := range results {
 		sortChanges(results[i].Changes)
 	}
 	sortChanges(mergedRoot)
 	return results, mergedRoot
+}
+
+// EnrichWhatifsFromPlan augments each WhatifResult's APIChanges with
+// plan-derived findings whose module address matches the call's
+// pair key. Surfaces force-new attribute changes and other plan-only
+// signals (replaces, deletes) alongside the static-side API diff for
+// the same call so reviewers see one merged view per call.
+//
+// Plan rows whose module address has no matching call are dropped
+// silently — whatif is per-call only with no rootChanges concept.
+// Use `tflens diff --enrich-with-plan` when root-level coverage
+// matters.
+//
+// Whatif's DirectImpact list is NOT touched. DirectImpact is
+// strictly the cross-validation result (would the parent's USE break
+// under the new child's API?); plan deltas are attribute-level
+// signals on the resource side, not cross-validation failures. The
+// caller can still gate the run on plan-derived Breaking findings —
+// see cmd/whatif.go's countWhatifBreaking — but the separation
+// keeps the two signal sources legible.
+//
+// Calls slice is mutated in place; nil plan is a no-op.
+func EnrichWhatifsFromPlan(calls []WhatifResult, p *plan.Plan, newProj *loader.Project) []WhatifResult {
+	if p == nil {
+		return calls
+	}
+	pairIdx := map[string]int{}
+	for i, r := range calls {
+		if r.Pair.Key != "" {
+			pairIdx[r.Pair.Key] = i
+		}
+	}
+	walkPlanChanges(p, newProj, func(moduleAddress string, c Change) {
+		key := planModuleKey(moduleAddress)
+		if i, ok := pairIdx[key]; ok {
+			calls[i].APIChanges = append(calls[i].APIChanges, c)
+		}
+	})
+	for i := range calls {
+		if len(calls[i].APIChanges) > 0 {
+			sortChanges(calls[i].APIChanges)
+		}
+	}
+	return calls
 }
 
 // changesForResourceChange returns the plan-derived Change entries for
@@ -598,21 +633,6 @@ func shouldSkipForStaleMove(rc plan.ResourceChange, deleteSkip, createSkip map[s
 		return createSkip[rc.Address]
 	}
 	return false
-}
-
-// stalePlanMoveChanges builds the collapsed entries for every detected
-// stale-move pair. Used by the flat EnrichFromPlan path; the per-
-// module routing variant builds them one at a time so each can be
-// routed by its To address's module path.
-func stalePlanMoveChanges(matches []movedPair, projectEntities map[string]entityRef) []Change {
-	if len(matches) == 0 {
-		return nil
-	}
-	out := make([]Change, 0, len(matches))
-	for _, m := range matches {
-		out = append(out, stalePlanMoveChange(m, projectEntities))
-	}
-	return out
 }
 
 // stalePlanMoveChange produces a single Informational Change for a

--- a/pkg/diff/enrich_test.go
+++ b/pkg/diff/enrich_test.go
@@ -454,6 +454,72 @@ func TestEnrichResultsFromPlanNilNoop(t *testing.T) {
 	}
 }
 
+// TestEnrichWhatifsFromPlanRoutesIntoAPIChanges confirms plan-derived
+// findings whose module address matches a call's pair key land
+// inside that call's APIChanges, while plan rows with no matching
+// call are dropped silently. (Whatif is per-call only — root-level
+// rows have no home there.)
+func TestEnrichWhatifsFromPlanRoutesIntoAPIChanges(t *testing.T) {
+	calls := []diff.WhatifResult{
+		{Pair: loader.ModuleCallPair{Key: "network", LocalName: "network"}},
+		{Pair: loader.ModuleCallPair{Key: "network.subnets", LocalName: "subnets"}},
+	}
+	p := planFixture(t, "nested_module.json")
+	got := diff.EnrichWhatifsFromPlan(calls, p, nil)
+
+	// network pair gets the vpc attribute delta from update on
+	// module.network.aws_vpc.main.
+	if n := len(got[0].APIChanges); n != 1 {
+		t.Fatalf("network APIChanges len = %d, want 1; got %+v", n, got[0].APIChanges)
+	}
+	if !strings.HasPrefix(got[0].APIChanges[0].Subject, "module.network.aws_vpc.main") {
+		t.Errorf("network APIChanges[0] routed wrong row: %q", got[0].APIChanges[0].Subject)
+	}
+	// network.subnets pair gets the create summary for the new subnet.
+	if n := len(got[1].APIChanges); n != 1 {
+		t.Fatalf("subnets APIChanges len = %d, want 1; got %+v", n, got[1].APIChanges)
+	}
+	if !strings.Contains(got[1].APIChanges[0].Detail, "plan creates") {
+		t.Errorf("subnets APIChanges[0] routed wrong row: %+v", got[1].APIChanges[0])
+	}
+	// DirectImpact untouched on every call — plan deltas don't
+	// constitute cross-validation failures.
+	for i, r := range got {
+		if len(r.DirectImpact) != 0 {
+			t.Errorf("call[%d] DirectImpact polluted by enrichment: %+v", i, r.DirectImpact)
+		}
+	}
+}
+
+// TestEnrichWhatifsFromPlanDropsUnmatched confirms plan rows for
+// modules that don't exist as calls are silently dropped (whatif is
+// per-call only) — they don't blow up, they don't show up in some
+// other call's APIChanges, and they don't leak into DirectImpact.
+func TestEnrichWhatifsFromPlanDropsUnmatched(t *testing.T) {
+	// No calls — every plan row is unmatched.
+	var calls []diff.WhatifResult
+	p := planFixture(t, "nested_module.json")
+	got := diff.EnrichWhatifsFromPlan(calls, p, nil)
+	if len(got) != 0 {
+		t.Errorf("calls should remain empty; got %+v", got)
+	}
+}
+
+// TestEnrichWhatifsFromPlanNilNoop pins the early-return contract:
+// nil plan returns the input verbatim.
+func TestEnrichWhatifsFromPlanNilNoop(t *testing.T) {
+	calls := []diff.WhatifResult{
+		{
+			Pair:       loader.ModuleCallPair{Key: "x"},
+			APIChanges: []diff.Change{{Subject: "preserved"}},
+		},
+	}
+	got := diff.EnrichWhatifsFromPlan(calls, nil, nil)
+	if len(got) != 1 || len(got[0].APIChanges) != 1 || got[0].APIChanges[0].Subject != "preserved" {
+		t.Errorf("nil plan should leave calls unchanged; got %+v", got)
+	}
+}
+
 // TestEnrichFromPlanRedactsSensitiveAndUnknown pins the renderer
 // substitution behaviour: a plan touching a sensitive attribute
 // must NOT spill the value into the Detail (it would land in CI

--- a/pkg/plan/testdata/statediff_count.json
+++ b/pkg/plan/testdata/statediff_count.json
@@ -1,0 +1,31 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.7.0",
+  "resource_changes": [
+    {
+      "address": "aws_vpc.main[0]",
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "main",
+      "index": 0,
+      "change": {
+        "actions": ["delete"],
+        "before": {"cidr_block": "10.0.0.0/16"},
+        "after": null,
+        "replace_paths": []
+      }
+    },
+    {
+      "address": "aws_vpc.unrelated",
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "unrelated",
+      "change": {
+        "actions": ["update"],
+        "before": {"tags": {"Env": "dev"}},
+        "after": {"tags": {"Env": "prod"}},
+        "replace_paths": []
+      }
+    }
+  ]
+}

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -167,6 +167,9 @@ func (m *MarkdownRenderer) Statediff(result *statediff.Result) {
 					for _, inst := range a.StateInstances {
 						fmt.Fprintf(m.W, "  - state instance: `%s`\n", inst)
 					}
+					for _, pi := range a.PlanInstances {
+						fmt.Fprintf(m.W, "  - 📋 plan: `%s` — %s\n", pi.Address, strings.Join(pi.Actions, ", "))
+					}
 				}
 				fmt.Fprintln(m.W)
 			}

--- a/pkg/render/statediff.go
+++ b/pkg/render/statediff.go
@@ -3,6 +3,7 @@ package render
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/dgr237/tflens/pkg/statediff"
 )
@@ -65,6 +66,9 @@ func writeStatediff(w io.Writer, r *statediff.Result) {
 				fmt.Fprintf(w, "    Affected: %s (%s)\n", ar.Address(), ar.MetaArg)
 				for _, inst := range ar.StateInstances {
 					fmt.Fprintf(w, "      • state instance: %s\n", inst)
+				}
+				for _, pi := range ar.PlanInstances {
+					fmt.Fprintf(w, "      • plan: %s [%s]\n", pi.Address, strings.Join(pi.Actions, ", "))
 				}
 			}
 		}

--- a/pkg/statediff/statediff.go
+++ b/pkg/statediff/statediff.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/dgr237/tflens/pkg/analysis"
 	"github.com/dgr237/tflens/pkg/loader"
+	"github.com/dgr237/tflens/pkg/plan"
 	"github.com/dgr237/tflens/pkg/tfstate"
 )
 
@@ -100,13 +101,40 @@ type SensitiveChange struct {
 // AffectedResource is one resource expansion (count / for_each) whose
 // underlying expression reaches a SensitiveChange. StateInstances is
 // populated when Analyze was given a state — these are the concrete
-// addresses currently tracked in state.
+// addresses currently tracked in state. PlanInstances is populated
+// by Result.EnrichWithPlan when a terraform plan JSON is supplied —
+// these are the concrete plan-side actions terraform will take.
+//
+// Mode distinguishes managed resources ("managed") from data sources
+// ("data"). Required to reconstruct the plan-side address shape for
+// data sources (which carry a `data.` prefix in plan addresses).
+// Older callers that don't populate Mode get the zero value, omitted
+// from JSON via omitempty so existing wire-format consumers aren't
+// broken.
 type AffectedResource struct {
-	Module         string   `json:"module"`
-	Type           string   `json:"type"`
-	Name           string   `json:"name"`
-	MetaArg        string   `json:"meta_arg"` // "count" or "for_each"
-	StateInstances []string `json:"state_instances,omitempty"`
+	Module         string         `json:"module"`
+	Type           string         `json:"type"`
+	Name           string         `json:"name"`
+	Mode           string         `json:"mode,omitempty"` // "managed" or "data"
+	MetaArg        string         `json:"meta_arg"`       // "count" or "for_each"
+	StateInstances []string       `json:"state_instances,omitempty"`
+	PlanInstances  []PlanInstance `json:"plan_instances,omitempty"`
+}
+
+// PlanInstance is one concrete plan ResourceChange that maps to an
+// AffectedResource. Address is the full plan address (including any
+// count/for_each index, so each instance is distinguishable);
+// Actions is the plan's actions list — `["update"]` for in-place,
+// `["delete", "create"]` for replace, etc.
+//
+// Used by `tflens statediff --enrich-with-plan`: the static side
+// flagged a count/for_each expression as touched by a sensitive
+// change; the plan side confirms which concrete instances WILL be
+// affected (not just COULD be). Pairs the "may break" signal with
+// the "will break" signal so reviewers see both at once.
+type PlanInstance struct {
+	Address string   `json:"address"`
+	Actions []string `json:"actions"`
 }
 
 // Address returns the resource's Terraform-style address (without
@@ -135,14 +163,117 @@ func Analyze(oldProj, newProj *loader.Project, state *tfstate.State) Result {
 	return result
 }
 
+// EnrichWithPlan augments the Result with concrete plan-derived
+// information. For each AffectedResource, looks up matching plan
+// ResourceChanges (by reconstructed plan address — module.X.Y.type.name,
+// with the data. prefix when applicable) and populates PlanInstances
+// with the per-instance actions terraform will take.
+//
+// The motivation: statediff's static analysis flags resources whose
+// count/for_each expression depends on a changed local/variable —
+// the "this CAN recompute" signal. The plan tells you which concrete
+// instances WILL recompute. Pairing them turns "the change touches
+// these N resources" into "the change replaces aws_subnet.foo[0],
+// updates aws_subnet.foo[1] in place, and creates aws_subnet.foo[2]"
+// — a much more actionable summary for the reviewer.
+//
+// AffectedResources with no plan match leave PlanInstances nil.
+// Possible reasons: the count expanded to 0 in the new plan, the
+// resource isn't in the plan at all, or the plan is stale. Renderers
+// can choose to flag this as a discrepancy.
+//
+// Index handling: plan addresses with `[0]` / `["us-east-1"]`
+// indices on the resource are kept VERBATIM in PlanInstance.Address
+// so each instance is visible. Module-path indices are stripped on
+// the lookup side because the source-side AffectedResource has only
+// the dotted module path with no index.
+//
+// Nil-safe on both sides: nil result or nil plan is a no-op.
+func (r *Result) EnrichWithPlan(p *plan.Plan) {
+	if r == nil || p == nil {
+		return
+	}
+	byStripped := map[string][]plan.ResourceChange{}
+	for _, rc := range p.ResourceChanges {
+		if rc.Change.IsNoOp() {
+			continue
+		}
+		byStripped[stripIndices(rc.Address)] = append(byStripped[stripIndices(rc.Address)], rc)
+	}
+	for sci := range r.SensitiveChanges {
+		sc := &r.SensitiveChanges[sci]
+		for ari := range sc.AffectedResources {
+			ar := &sc.AffectedResources[ari]
+			expected := affectedResourceFullAddress(*ar)
+			for _, rc := range byStripped[expected] {
+				ar.PlanInstances = append(ar.PlanInstances, PlanInstance{
+					Address: rc.Address,
+					Actions: append([]string(nil), rc.Change.Actions...),
+				})
+			}
+		}
+	}
+}
+
+// affectedResourceFullAddress reconstructs the Terraform plan address
+// shape for an AffectedResource so it can be matched against the
+// plan's ResourceChanges. statediff stores Module as a dotted path
+// without `module.` prefixes (e.g. "vpc.subnets") — the plan uses
+// fully-prefixed addresses (e.g. "module.vpc.module.subnets"), so
+// we re-add the prefixes here. Data sources gain the `data.` infix.
+func affectedResourceFullAddress(ar AffectedResource) string {
+	var modPrefix string
+	if ar.Module != "" {
+		parts := strings.Split(ar.Module, ".")
+		prefixed := make([]string, 0, 2*len(parts))
+		for _, p := range parts {
+			prefixed = append(prefixed, "module", p)
+		}
+		modPrefix = strings.Join(prefixed, ".")
+	}
+	base := ar.Type + "." + ar.Name
+	if ar.Mode == "data" {
+		base = "data." + base
+	}
+	if modPrefix == "" {
+		return base
+	}
+	return modPrefix + "." + base
+}
+
+// stripIndices removes count/for_each `[idx]` suffixes from any
+// segment of a Terraform address. Duplicated from pkg/diff/enrich.go's
+// helper rather than imported to avoid a statediff → diff dependency
+// just for this single function.
+func stripIndices(s string) string {
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '[':
+			depth++
+		case ']':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if depth == 0 {
+				b.WriteByte(s[i])
+			}
+		}
+	}
+	return b.String()
+}
+
 // formatEntityAddress turns "resource.aws_vpc.main" + module prefix
 // into a Terraform-style address "module.vpc.aws_vpc.main". Returns
 // the raw ID if the shape is unfamiliar.
 func formatEntityAddress(modPath, entityID string) string {
-	addr := entityID
-	if strings.HasPrefix(entityID, "resource.") {
-		addr = strings.TrimPrefix(entityID, "resource.")
-	}
+	addr, _ := strings.CutPrefix(entityID, "resource.")
 	if modPath == "" {
 		return addr
 	}
@@ -384,10 +515,15 @@ func flagResource(
 			if !triggered[cand.entityID()] {
 				continue
 			}
+			mode := "managed"
+			if e.Kind == analysis.KindData {
+				mode = "data"
+			}
 			affected := AffectedResource{
 				Module:  modPath,
 				Type:    e.Type,
 				Name:    e.Name,
+				Mode:    mode,
 				MetaArg: metaArg.name,
 			}
 			if state != nil {

--- a/pkg/statediff/statediff_test.go
+++ b/pkg/statediff/statediff_test.go
@@ -3,9 +3,11 @@ package statediff_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/dgr237/tflens/pkg/loader"
+	"github.com/dgr237/tflens/pkg/plan"
 	"github.com/dgr237/tflens/pkg/statediff"
 )
 
@@ -258,6 +260,89 @@ resource "aws_instance" "web" {
 	if c.Kind != "variable" || c.Name != "n" {
 		t.Errorf("change = %+v, want variable.n", c)
 	}
+}
+
+// TestEnrichWithPlanPopulatesPlanInstances confirms that statediff's
+// "static analysis flagged this resource's count expression" signal
+// gets paired with the plan's "here are the concrete instance
+// actions" signal. The fixture: a count goes from 1 → 0; the plan
+// shows aws_vpc.main[0] being destroyed.
+func TestEnrichWithPlanPopulatesPlanInstances(t *testing.T) {
+	old := loadProj(t, `
+locals {
+  enabled = 1
+}
+resource "aws_vpc" "main" {
+  count       = local.enabled
+  cidr_block  = "10.0.0.0/16"
+}
+`)
+	new := loadProj(t, `
+locals {
+  enabled = 0
+}
+resource "aws_vpc" "main" {
+  count       = local.enabled
+  cidr_block  = "10.0.0.0/16"
+}
+`)
+	r := statediff.Analyze(old, new, nil)
+	if len(r.SensitiveChanges) != 1 || len(r.SensitiveChanges[0].AffectedResources) != 1 {
+		t.Fatalf("expected 1 sensitive change with 1 affected resource; got %+v", r)
+	}
+
+	// Affected resource has no plan info before enrichment.
+	if got := len(r.SensitiveChanges[0].AffectedResources[0].PlanInstances); got != 0 {
+		t.Errorf("PlanInstances should be empty before enrichment; got %d", got)
+	}
+
+	// Mode field should be populated by the new flagResource code path.
+	if mode := r.SensitiveChanges[0].AffectedResources[0].Mode; mode != "managed" {
+		t.Errorf("Mode = %q, want managed", mode)
+	}
+
+	p := loadPlanFixture(t, "statediff_count.json")
+	r.EnrichWithPlan(p)
+
+	got := r.SensitiveChanges[0].AffectedResources[0].PlanInstances
+	if len(got) != 1 {
+		t.Fatalf("PlanInstances len = %d, want 1; got %+v", len(got), got)
+	}
+	if got[0].Address != "aws_vpc.main[0]" {
+		t.Errorf("PlanInstance.Address = %q, want aws_vpc.main[0]", got[0].Address)
+	}
+	if len(got[0].Actions) != 1 || got[0].Actions[0] != "delete" {
+		t.Errorf("PlanInstance.Actions = %v, want [delete]", got[0].Actions)
+	}
+}
+
+// TestEnrichWithPlanNilNoop pins the early-return contract.
+func TestEnrichWithPlanNilNoop(t *testing.T) {
+	r := &statediff.Result{
+		SensitiveChanges: []statediff.SensitiveChange{{
+			AffectedResources: []statediff.AffectedResource{{
+				Type: "aws_vpc", Name: "main",
+			}},
+		}},
+	}
+	r.EnrichWithPlan(nil)
+	if len(r.SensitiveChanges[0].AffectedResources[0].PlanInstances) != 0 {
+		t.Error("nil plan should leave PlanInstances empty")
+	}
+}
+
+// loadPlanFixture loads a plan testdata file from pkg/plan/testdata
+// — shared with the diff package's enrich tests so we don't have to
+// duplicate fixtures.
+func loadPlanFixture(t *testing.T, name string) *plan.Plan {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(file), "..", "plan", "testdata", name)
+	p, err := plan.Load(path)
+	if err != nil {
+		t.Fatalf("plan.Load %s: %v", path, err)
+	}
+	return p
 }
 
 // loadProj writes src to a temp dir and loads it as a Project. Used


### PR DESCRIPTION
## Summary

Plan enrichment is no longer diff-only — both `whatif` and `statediff` now take `--enrich-with-plan plan.json`.

**`tflens whatif --enrich-with-plan`** — plan-derived findings whose module address matches a call's pair key land inside that call's `APIChanges`, alongside the static-side API diff for the same call. Plan rows whose module address has no matching call are dropped silently (whatif is per-call only — root-level coverage stays with `tflens diff --enrich-with-plan`). Plan-derived Breaking findings count toward the CI exit code in addition to DirectImpact: a force-new attribute change in a child IS a consumer concern even when the parent's USE cross-validates cleanly. New `diff.EnrichWhatifsFromPlan(calls, plan, project)` entry point.

**`tflens statediff --enrich-with-plan`** — the higher-value half. Statediff's static analysis flags resources whose `count` / `for_each` expression depends on a changed local or variable default — the "this CAN recompute" signal. Plan enrichment pairs that with the plan's "here are the N concrete instances that WILL be affected": each `AffectedResource` gets a `PlanInstances` list with per-instance plan addresses (including count/for_each indices) and the actions terraform will take (`["update"]`, `["delete", "create"]`, etc.). Turns "this change touches a count expression" into "this change destroys aws_subnet.foo[0], updates aws_subnet.foo[1] in place, and creates aws_subnet.foo[2]" — much more actionable for the reviewer.

New types/fields:
- `statediff.PlanInstance` (`Address` + `Actions`)
- `statediff.AffectedResource.PlanInstances []PlanInstance` (omitempty)
- `statediff.AffectedResource.Mode string` (omitempty — `"managed"` / `"data"`, needed to reconstruct the plan-side address shape correctly for data sources)
- `(*statediff.Result).EnrichWithPlan(plan)` method

**Refactor:** extracted `walkPlanChanges(p, project, route)` from the existing per-rc enrichment loop so all three callers — `EnrichFromPlan` / `EnrichResultsFromPlan` / `EnrichWhatifsFromPlan` — share the no-op + stale-move skipping + source-position attribution logic with their own routing strategy. ~50 lines of duplication removed.

**Renderers:** console adds `• plan: <address> [actions]` under each affected resource; markdown adds `📋 plan: <address> — actions`. Whatif's renderer needs no change because `APIChanges` already supports plan-tagged Changes via the existing `[plan]` / 📋 prefix logic.

## Test plan

- [x] `make check` passes
- [x] `TestEnrichWhatifsFromPlanRoutesIntoAPIChanges` confirms plan rows route to matching calls' APIChanges; DirectImpact untouched
- [x] `TestEnrichWhatifsFromPlanDropsUnmatched` confirms unmatched rows are silently dropped (whatif is per-call only)
- [x] `TestEnrichWhatifsFromPlanNilNoop` pins the early-return contract
- [x] `TestEnrichWithPlanPopulatesPlanInstances` confirms statediff's AffectedResource gets PlanInstances after enrichment, with the right Address + Actions
- [x] `TestEnrichWithPlanNilNoop` pins the early-return contract
- [x] All existing `pkg/diff` / `pkg/statediff` / `pkg/render` / `cmd` tests still pass — backward-compatible: omitempty new fields don't appear in JSON output unless populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)