### PR TITLE
[demo] dogfood: exercise the three finding types — DO NOT MERGE

### DIFF
--- a/docs/example-module/main.tf
+++ b/docs/example-module/main.tf
@@ -10,17 +10,17 @@
 
 variable "vpc_cidr" {
   type    = string
-  default = "10.0.0.0/16"
+  default = "10.1.0.0/16" // [demo] tracked attribute change — diff should flag Breaking via the # tflens:track marker on aws_vpc.main.cidr_block
 }
 
 variable "subnet_count" {
   type    = number
-  default = 3
+  default = 1 // [demo] 3 → 1, statediff should flag Breaking via the count-reaches-changed-default detector
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type = map(string)
+  // [demo] default removed → diff should flag Breaking ("variable now required")
 }
 
 locals {


### PR DESCRIPTION
> **Demo PR — close without merging.** This PR exists to validate that the dogfood workflow's three jobs (diff / statediff / whatif) surface meaningful output for the normal case, not just the first-PR \"everything added\" edge case the workflow shipped with.

## What it does

Three deliberate changes to `docs/example-module/main.tf`, each firing a different mechanism:

| Change | Expected to fire |
|---|---|
| `var.vpc_cidr` default `10.0.0.0/16` → `10.1.0.0/16` | `tflens diff` Breaking via the `# tflens:track` marker on `aws_vpc.main.cidr_block` (marker description appears as the hint) |
| `var.subnet_count` default `3` → `1` | `tflens statediff` Breaking via the count-reaches-changed-default detector (silently destroys 2 instances at apply time) |
| `var.tags` default `{}` removed | `tflens diff` Breaking (\"variable now required\") |

## Expected sticky comments

After CI runs, three sticky comments should appear on this PR (one per matrix job, with distinct `comment-tag`s):

- **`tflens diff`** — should show 2 Breaking findings: the tracked-attribute change AND the tags default removal.
- **`tflens statediff`** — should show 1 sensitive-local change with `aws_subnet.public (count)` flagged as affected.
- **`tflens validate`** — should report no validation errors (the changes are all syntactically and semantically valid; they just break the API contract).

If the comments match those expectations, close this PR. If anything is off, that's a bug in the dogfood / action / tflens worth investigating.

## Verified locally

```
=== diff ===
Root module:
  Breaking (2):
    resource.aws_vpc.main.cidr_block: variable.vpc_cidr changed: \"10.0.0.0/16\" → \"10.1.0.0/16\"
      hint: VPC CIDR is load-bearing — coordinate with downstream consumers
    variable.tags: default removed (variable became required)
      hint: keep the default; only remove it if every caller already passes the input explicitly

=== statediff ===
Value changes that may alter count/for_each expansion:
  - variable.subnet_count
      old: 3
      new: 1
    Affected: aws_subnet.public (count)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)