### PR TITLE
Action metadata: rename + shorten description for Marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to tflens are documented here. The format is loosely based o
 
 ## [Unreleased]
 
+### Changed
+
+- **GitHub Action metadata: name and description tightened for Marketplace publication.** Renamed from `tflens` to `tflens — Terraform breaking-change detector` (the bare name was rejected as non-unique by GitHub Marketplace). Description trimmed from ~250 chars (multi-line block) to 105 chars (single line) to fit Marketplace's 125-char limit. Behaviour unchanged — only the metadata humans see on the Marketplace listing differs. The `uses: dgr237/tflens@vX.Y.Z` invocation form is unaffected.
+
 ## [0.16.1] — 2026-04-26
 
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,5 @@
-name: 'tflens'
-description: |
-  Run tflens (static Terraform analyser) against a Terraform project and
-  surface the result as a sticky PR comment + workflow step summary.
-  Wraps `tflens diff | whatif | statediff | validate` with PR-comment
-  plumbing so CI integration is a single uses: line.
+name: 'tflens — Terraform breaking-change detector'
+description: 'Run tflens against Terraform on every PR. Posts diff / whatif / statediff results as a sticky PR comment.'
 author: 'dgr237'
 branding:
   icon: 'eye'


### PR DESCRIPTION
GitHub Marketplace publication rejected the current action.yml metadata:

> **Name:** \`tflens\` — Name must be unique. Cannot match an existing action, user or organization name.
> **Description:** must be less than 125 characters.

## Changes

| Field | Before | After |
|---|---|---|
| `name` | `tflens` (rejected as non-unique) | `tflens — Terraform breaking-change detector` (44 chars) |
| `description` | ~250 chars, multi-line block | 105 chars, single line: \"Run tflens against Terraform on every PR. Posts diff / whatif / statediff results as a sticky PR comment.\" |

Behaviour unchanged — the action's inputs, outputs, and composite-action steps are untouched. The only visible difference is the Marketplace listing's name + tagline.

The `uses: dgr237/tflens@vX.Y.Z` invocation in consumer workflows is unaffected (the URL slug derives from the GitHub repo name, not action.yml's `name:` field).

## After this merges

Once the auto-release tags v0.16.x with the updated metadata, edit that release on GitHub and re-tick the \"Publish this Action to the GitHub Marketplace\" checkbox — the validation should pass this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)