### PR TITLE
Add Code of Conduct + issue / PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,98 @@
+name: Bug report
+description: tflens did something wrong, crashed, or produced unexpected output
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! The more specific the repro, the faster we can fix it.
+
+        **Before filing:** please check that the issue isn't already covered in the [docs/commands/](https://github.com/dgr237/tflens/tree/main/docs/commands) reference for the affected subcommand — many surprising behaviours are documented in the "What it does NOT catch" sections.
+
+  - type: input
+    id: version
+    attributes:
+      label: tflens version
+      description: Output of `tflens --version` (or the git SHA / release tag if you're running from source)
+      placeholder: "v0.16.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: subcommand
+    attributes:
+      label: Subcommand
+      description: Which command surfaced the bug?
+      options:
+        - validate
+        - diff
+        - whatif
+        - statediff
+        - export
+        - inventory / deps / impact / unused / cycles / graph / fmt / cache
+        - GitHub Action wrapper
+        - other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug in one or two sentences.
+      placeholder: "Running `tflens diff --ref main` against ./modules/network produced ... but I expected ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro steps
+      description: Minimal HCL + commands that reproduce the issue. The smaller the better — single `main.tf` is ideal.
+      placeholder: |
+        ```hcl
+        # main.tf
+        variable "x" { type = string }
+        ```
+
+        ```bash
+        tflens diff --ref main .
+        ```
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual output
+      description: Paste the actual output (or the error / stack trace).
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected output
+      description: What did you expect tflens to do or report?
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS / shell
+      description: Linux/macOS/Windows + which shell. CI runner OS counts too.
+      placeholder: "Ubuntu 22.04, bash"
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Workarounds you've tried, related issues, surrounding context.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/dgr237/tflens/issues/new?template=feature_request.yml
+    about: |
+      No Discussions board yet — please open a feature request describing what you're trying to do.
+      Most "questions" turn out to be requests for clearer docs or a missing flag, both of which are useful issues.
+  - name: Security report
+    url: https://github.com/dgr237/tflens/security/advisories/new
+    about: |
+      Found a vulnerability? Report privately via GitHub Security Advisories. See SECURITY.md for scope and process.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,62 @@
+name: Feature request
+description: Suggest a new check, flag, output mode, or anything else
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for thinking about how to make tflens better.
+
+        **Scope reminder:** tflens is a static, schema-free Terraform analyser focused on change-impact detection across refs. See [docs/comparison.md](https://github.com/dgr237/tflens/blob/main/docs/comparison.md) for what tflens deliberately doesn't try to do (security posture → Checkov; provider-rule linting → TFLint; behaviour preview → terraform plan). Features inside that scope are very welcome; features outside it usually aren't a good fit.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: The user-facing situation, not the proposed solution. "I'm trying to X but tflens does Y" is the right shape.
+      placeholder: "When I rename a module call, the diff reports both a removed and added module — I'd like it to be recognised as a rename."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed shape (optional)
+      description: If you have a concrete idea of what the fix or feature would look like — flag, check, output format, etc. — describe it here. Skip if you'd rather discuss the problem first.
+    validations:
+      required: false
+
+  - type: textarea
+    id: workarounds
+    attributes:
+      label: Existing workarounds
+      description: What are you doing today to work around the missing feature? (Even "manually reviewing every PR diff" is useful context.)
+    validations:
+      required: false
+
+  - type: textarea
+    id: prior-art
+    attributes:
+      label: Prior art
+      description: Do other tools (TFLint, Checkov, terraform-docs, etc.) solve this? How? Links + brief notes welcome.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: subcommand
+    attributes:
+      label: Which subcommand would this affect?
+      multiple: true
+      options:
+        - validate
+        - diff
+        - whatif
+        - statediff
+        - export
+        - tracked attributes (# tflens:track)
+        - GitHub Action wrapper
+        - new subcommand
+        - cross-cutting / not sure
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+Thanks for contributing! Fill in the sections below — keep it terse, the
+PR description shows up in the auto-release notes if you label this PR
+with release:patch / minor / major.
+
+Delete this comment block before submitting.
+-->
+
+## Summary
+
+<!-- 1–3 bullets. What changed and why. Link the issue if there is one. -->
+
+-
+
+## Test plan
+
+<!-- Checkbox list of how you verified the change. Real commands you ran,
+     not aspirational ones. -->
+
+- [ ] `make check` passes
+- [ ]
+
+## CHANGELOG
+
+<!-- User-visible changes need an entry under `## [Unreleased]` in
+     CHANGELOG.md (grouped by Added / Changed / Deprecated / Removed /
+     Fixed / Security).
+
+     If the change is purely internal (refactor, test-only, dep bump
+     with no behaviour change, etc.), apply the `no-changelog` label
+     instead. The changelog-check workflow auto-skips PRs that only
+     touch tests / testdata / .github / scripts / top-level Markdown. -->
+
+- [ ] CHANGELOG.md updated, OR `no-changelog` label applied, OR all changed files are in the auto-skip list.
+
+## Release label
+
+<!-- If this is user-facing and ready to ship on merge, apply ONE of:
+
+     - `release:patch` — bug fix, doc fix, internal cleanup with no API change
+     - `release:minor` — backwards-compatible feature add
+     - `release:major` — breaking change
+
+     PRs without a release label are silently skipped by auto-release —
+     `[Unreleased]` entries accumulate until the next release-labelled
+     merge. That's fine for a series of small changes you want to ship
+     together. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to tflens are documented here. The format is loosely based o
 
 ## [Unreleased]
 
+### Documentation
+
+- **Repo hygiene: Code of Conduct + issue / PR templates.** New [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) adopts Contributor Covenant 2.1 (linked rather than vendored, so upstream updates flow automatically) with the maintainer contact email. New `.github/ISSUE_TEMPLATE/` directory with two GitHub-form templates — bug report (version, subcommand, repro, actual vs expected) and feature request (problem-first framing, prior-art prompt, scope reminder pointing at `docs/comparison.md`) — plus a `config.yml` that disables blank issues and routes "questions" to the feature-request template + security reports to GitHub Security Advisories. New [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) with the Summary / Test plan / CHANGELOG / Release-label sections that mirror the shape of recent merged PRs. Standard OSS-hygiene set; reduces friction for first-time contributors and signals "this is a maintained project taking contributions seriously" — useful as the action's Marketplace listing makes the repo more discoverable.
+
 ## [0.16.2] — 2026-04-26
 
 ### Changed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+This project adopts the [**Contributor Covenant**](https://www.contributor-covenant.org/) v2.1 as its Code of Conduct. The full text — including the pledge, standards, enforcement guidelines, and attribution — is at:
+
+**<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>**
+
+## Scope
+
+The Code of Conduct applies within all project spaces — the GitHub repository, issues, pull requests, discussions, and any other forum where someone is representing the project or its community.
+
+## Reporting
+
+Report a Code of Conduct concern to the project maintainer at **<david.gareth.roberts@gmail.com>**. Reports will be reviewed and investigated promptly and fairly. The maintainer is obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement
+
+The maintainer follows the [Community Impact Guidelines](https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines) from Contributor Covenant 2.1 when determining the consequences for any action deemed in violation of this Code of Conduct.
+
+## Why we adopt the Contributor Covenant
+
+It's the most widely-used CoC across open-source projects, which means contributors arriving from elsewhere already know what's expected — no surprises, no need to read a bespoke document. Updates to the upstream Covenant flow into projects that link rather than vendor, so this document stays current automatically.


### PR DESCRIPTION
Standard OSS-hygiene set. Useful especially as the action's Marketplace listing makes the repo more discoverable to first-time contributors.

## Files added

- **[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)** — adopts [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) by linking to the canonical document rather than vendoring the text. Upstream updates flow automatically; this file just records the adoption + the contact email + scope.

- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — GitHub-form template: version, subcommand (dropdown), description, repro steps, actual output, expected output, OS/shell, extras. Prefixed with a reminder to check the per-command "What it does NOT catch" sections in `docs/commands/` before filing.

- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — problem-first framing (problem → proposal → workarounds → prior art → affected subcommand). Scope reminder at the top points at [`docs/comparison.md`](docs/comparison.md) so requests for things tflens deliberately doesn't try to do (security posture, provider-rule linting, plan replacement) get redirected to the right tool.

- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues; routes "Questions" to the feature-request template (no GitHub Discussions board yet) and "Security reports" to GitHub Security Advisories per `SECURITY.md`.

- **[`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)** — Summary / Test plan / CHANGELOG / Release label sections, mirroring the shape of recent merged PRs (and the auto-release workflow's expectations).

## Test plan

- [x] CHANGELOG entry under `## [Unreleased]` (`### Documentation` group)
- [ ] Visual review on GitHub once merged — confirm the issue templates render in "New issue" UI and the PR template auto-populates the body of new PRs
- [ ] Confirm the CoC link in the GitHub repo's "Community Standards" tab shows ✅ (currently shows as missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)